### PR TITLE
Remove jsonrpc field from JSONRPCRequest so OVSDB connections work (JSON-RPC 1.0)

### DIFF
--- a/Sources/SwiftOVN/Models/JSONRPCRequest.swift
+++ b/Sources/SwiftOVN/Models/JSONRPCRequest.swift
@@ -1,13 +1,11 @@
 import Foundation
 
 public struct JSONRPCRequest: Codable, Sendable {
-    public let jsonrpc: String
     public let method: String
     public let params: JSONRPCParams?
     public let id: JSONRPCIdentifier?
 
     public init(method: String, params: JSONRPCParams? = nil, id: JSONRPCIdentifier? = nil) {
-        self.jsonrpc = "2.0"
         self.method = method
         self.params = params
         self.id = id

--- a/Tests/SwiftOVNTests/OVNManagerTests.swift
+++ b/Tests/SwiftOVNTests/OVNManagerTests.swift
@@ -11,7 +11,6 @@ final class OVNManagerTests: XCTestCase {
             id: .string("test-1")
         )
         
-        XCTAssertEqual(request.jsonrpc, "2.0")
         XCTAssertEqual(request.method, "list_dbs")
         XCTAssertNil(request.params)
         
@@ -220,7 +219,6 @@ final class JSONRPCClientMockTests: XCTestCase {
         let decodedRequest = try decoder.decode(JSONRPCRequest.self, from: data)
         
         XCTAssertEqual(decodedRequest.method, request.method)
-        XCTAssertEqual(decodedRequest.jsonrpc, request.jsonrpc)
     }
     
     func testOVSDBOperationSerialization() throws {


### PR DESCRIPTION
## Summary

OVSDB (RFC 7047) speaks **JSON-RPC 1.0**, which has no `jsonrpc` member. `JSONRPCRequest` was hardcoding `"jsonrpc":"2.0"` on every request, so `ovsdb-server` silently dropped each one. The initial `echo` handshake hung and every connection failed with `timeoutError` after 30s.

This was the actual cause of the "connection times out" symptom — separate from the framing issue (#4 / #5), which was necessary but not sufficient.

## Changes

- `Sources/SwiftOVN/Models/JSONRPCRequest.swift` — drop the `jsonrpc` stored property and its `init` assignment. OVSDB has no use for it, and no other code reads `.jsonrpc`.
- `Tests/SwiftOVNTests/OVNManagerTests.swift` — remove the two assertions that referenced the deleted field.

The emitted request is now e.g. `{"params":["echo"],"method":"echo","id":1}` with no `jsonrpc` member, which `ovsdb-server` replies to instantly.

## Testing

- `swift build` — succeeds
- `swift test` — 25 tests, 0 failures

Fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)