### PR TITLE
Speak JSON-RPC 1.0 for OVSDB (drop jsonrpc:2.0 member)

### DIFF
--- a/Sources/SwiftOVN/Models/JSONRPCRequest.swift
+++ b/Sources/SwiftOVN/Models/JSONRPCRequest.swift
@@ -1,13 +1,15 @@
 import Foundation
 
 public struct JSONRPCRequest: Codable, Sendable {
-    public let jsonrpc: String
+    // OVSDB (RFC 7047) speaks JSON-RPC 1.0, which has no "jsonrpc" member.
+    // Emitting "jsonrpc":"2.0" makes ovsdb-server silently drop the request
+    // (it never replies), so every OVSDB connection times out. The field is
+    // therefore intentionally omitted from the wire format.
     public let method: String
     public let params: JSONRPCParams?
     public let id: JSONRPCIdentifier?
 
     public init(method: String, params: JSONRPCParams? = nil, id: JSONRPCIdentifier? = nil) {
-        self.jsonrpc = "2.0"
         self.method = method
         self.params = params
         self.id = id


### PR DESCRIPTION
OVSDB (RFC 7047) uses **JSON-RPC 1.0**, which has no `jsonrpc` member. Emitting `"jsonrpc":"2.0"` makes `ovsdb-server` silently drop the request and never reply, so the initial `echo` handshake — and therefore every OVN/OVS connection — times out after 30s. `ovn-nbctl` works against the same socket because it sends proper 1.0.

### Change
Remove the `jsonrpc` field from `JSONRPCRequest` (no other code reads it).

### Verified
Before: `Sending {"params":["echo"],"id":1,"jsonrpc":"2.0","method":"echo"}` → no response → `timeoutError`.
After: `Sending {"params":["echo"],"method":"echo","id":1}` → `{"id":1,"result":["echo"],"error":null}` → `Echo test completed successfully` → connects to `OVN_Northbound` and `Open_vSwitch`.

Fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)