### PR TITLE
Keep map<string,string> values as strings (don't UUID-wrap them)

### DIFF
--- a/Sources/SwiftOVN/Managers/OVNManager.swift
+++ b/Sources/SwiftOVN/Managers/OVNManager.swift
@@ -693,7 +693,12 @@ private extension OVNManager {
         }
     }
     
-    func convertToJSONValue(_ object: Any) throws -> JSONValue {
+    /// - Parameter mapValuesAreUUIDRefs: when the object is a map, whether its
+    ///   values are UUID references and must be emitted as `["uuid", ...]`
+    ///   atoms, versus a plain `map<string,string>` (e.g. `external_ids`) whose
+    ///   values stay strings. (No OVN map column is UUID-valued today, but the
+    ///   parameter keeps the string/uuid distinction explicit here too.)
+    func convertToJSONValue(_ object: Any, mapValuesAreUUIDRefs: Bool = false) throws -> JSONValue {
         if object is NSNull {
             return .null
         } else if let bool = object as? Bool {
@@ -714,14 +719,17 @@ private extension OVNManager {
             return .array([.string("set"), .array(jsonArray)])
         } else if let dict = object as? [String: Any] {
             // OVSDB expects maps in the format ["map", [["key", "value"], ...]].
-            // These maps (e.g. external_ids) are map<string,string>, so their
-            // values must stay strings. Do NOT run UUID-atom detection on them,
-            // or a UUID-shaped value (e.g. a vm-id in external_ids) becomes
-            // ["uuid",...] and ovsdb-server rejects it ("expected string").
+            // For string-string maps (external_ids, other_config, options, ...)
+            // values must stay strings — running UUID-atom detection on them
+            // turns a UUID-shaped value (e.g. a vm-id in external_ids) into
+            // ["uuid",...], which ovsdb-server rejects ("expected string"). For
+            // UUID-valued maps, keep the reference atoms by recursing.
             var mapArray: [JSONValue] = []
             for (key, value) in dict {
                 let valueJSON: JSONValue
-                if let stringValue = value as? String {
+                if mapValuesAreUUIDRefs {
+                    valueJSON = try convertToJSONValue(value)
+                } else if let stringValue = value as? String {
                     valueJSON = .string(stringValue)
                 } else {
                     valueJSON = try convertToJSONValue(value)

--- a/Sources/SwiftOVN/Managers/OVNManager.swift
+++ b/Sources/SwiftOVN/Managers/OVNManager.swift
@@ -713,11 +713,20 @@ private extension OVNManager {
             let jsonArray = try array.map { try convertToJSONValue($0) }
             return .array([.string("set"), .array(jsonArray)])
         } else if let dict = object as? [String: Any] {
-            // OVSDB expects maps in the format ["map", [["key", "value"], ...]]
+            // OVSDB expects maps in the format ["map", [["key", "value"], ...]].
+            // These maps (e.g. external_ids) are map<string,string>, so their
+            // values must stay strings. Do NOT run UUID-atom detection on them,
+            // or a UUID-shaped value (e.g. a vm-id in external_ids) becomes
+            // ["uuid",...] and ovsdb-server rejects it ("expected string").
             var mapArray: [JSONValue] = []
             for (key, value) in dict {
-                let pair: [JSONValue] = [.string(key), try convertToJSONValue(value)]
-                mapArray.append(.array(pair))
+                let valueJSON: JSONValue
+                if let stringValue = value as? String {
+                    valueJSON = .string(stringValue)
+                } else {
+                    valueJSON = try convertToJSONValue(value)
+                }
+                mapArray.append(.array([.string(key), valueJSON]))
             }
             return .array([.string("map"), .array(mapArray)])
         } else {

--- a/Sources/SwiftOVN/Managers/OVSManager.swift
+++ b/Sources/SwiftOVN/Managers/OVSManager.swift
@@ -694,7 +694,11 @@ private extension OVSManager {
         
         // Columns whose map values are UUID references (map<_,uuid>) rather than
         // strings, so their values must be emitted as ["uuid", ...] atoms.
-        let uuidValuedMapColumns: Set<String> = ["queues"]
+        // These are the reference-valued map columns in the Open_vSwitch schema:
+        // QoS.queues (map<integer,Queue>) and Bridge.flow_tables
+        // (map<integer,Flow_Table>). All other maps here (external_ids,
+        // other_config, options, status, rstp_status, ...) are map<string,string>.
+        let uuidValuedMapColumns: Set<String> = ["queues", "flow_tables"]
 
         var row: OVSDBRow = [:]
         for (key, value) in jsonObject {

--- a/Sources/SwiftOVN/Managers/OVSManager.swift
+++ b/Sources/SwiftOVN/Managers/OVSManager.swift
@@ -779,11 +779,20 @@ private extension OVSManager {
             let jsonArray = try array.map { try convertToJSONValue($0) }
             return .array([.string("set"), .array(jsonArray)])
         } else if let dict = object as? [String: Any] {
-            // OVSDB expects maps in the format ["map", [["key", "value"], ...]]
+            // OVSDB expects maps in the format ["map", [["key", "value"], ...]].
+            // These maps (e.g. external_ids) are map<string,string>, so their
+            // values must stay strings. Do NOT run UUID-atom detection on them,
+            // or a UUID-shaped value becomes ["uuid",...] and ovsdb-server
+            // rejects it ("expected string").
             var mapArray: [JSONValue] = []
             for (key, value) in dict {
-                let pair: [JSONValue] = [.string(key), try convertToJSONValue(value)]
-                mapArray.append(.array(pair))
+                let valueJSON: JSONValue
+                if let stringValue = value as? String {
+                    valueJSON = .string(stringValue)
+                } else {
+                    valueJSON = try convertToJSONValue(value)
+                }
+                mapArray.append(.array([.string(key), valueJSON]))
             }
             return .array([.string("map"), .array(mapArray)])
         } else {

--- a/Sources/SwiftOVN/Managers/OVSManager.swift
+++ b/Sources/SwiftOVN/Managers/OVSManager.swift
@@ -692,10 +692,17 @@ private extension OVSManager {
         let data = try encoder.encode(object)
         let jsonObject = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
         
+        // Columns whose map values are UUID references (map<_,uuid>) rather than
+        // strings, so their values must be emitted as ["uuid", ...] atoms.
+        let uuidValuedMapColumns: Set<String> = ["queues"]
+
         var row: OVSDBRow = [:]
         for (key, value) in jsonObject {
             if key != "_uuid" { // Skip UUID for inserts
-                row[key] = try convertToJSONValue(value)
+                row[key] = try convertToJSONValue(
+                    value,
+                    mapValuesAreUUIDRefs: uuidValuedMapColumns.contains(key)
+                )
             }
         }
         return row
@@ -759,7 +766,11 @@ private extension OVSManager {
         }
     }
     
-    func convertToJSONValue(_ object: Any) throws -> JSONValue {
+    /// - Parameter mapValuesAreUUIDRefs: when the object is a map, whether its
+    ///   values are UUID references (e.g. `QoS.queues`, a `map<integer,uuid>`)
+    ///   and must be emitted as `["uuid", ...]` atoms, versus a plain
+    ///   `map<string,string>` (e.g. `external_ids`) whose values stay strings.
+    func convertToJSONValue(_ object: Any, mapValuesAreUUIDRefs: Bool = false) throws -> JSONValue {
         if object is NSNull {
             return .null
         } else if let bool = object as? Bool {
@@ -780,14 +791,17 @@ private extension OVSManager {
             return .array([.string("set"), .array(jsonArray)])
         } else if let dict = object as? [String: Any] {
             // OVSDB expects maps in the format ["map", [["key", "value"], ...]].
-            // These maps (e.g. external_ids) are map<string,string>, so their
-            // values must stay strings. Do NOT run UUID-atom detection on them,
-            // or a UUID-shaped value becomes ["uuid",...] and ovsdb-server
-            // rejects it ("expected string").
+            // For string-string maps (external_ids, other_config, options, ...)
+            // values must stay strings — running UUID-atom detection on them
+            // turns a UUID-shaped value into ["uuid",...], which ovsdb-server
+            // rejects ("expected string"). For UUID-valued maps (queues), keep
+            // the reference atoms by recursing so the UUID detection applies.
             var mapArray: [JSONValue] = []
             for (key, value) in dict {
                 let valueJSON: JSONValue
-                if let stringValue = value as? String {
+                if mapValuesAreUUIDRefs {
+                    valueJSON = try convertToJSONValue(value)
+                } else if let stringValue = value as? String {
                     valueJSON = .string(stringValue)
                 } else {
                     valueJSON = try convertToJSONValue(value)


### PR DESCRIPTION
`convertToJSONValue` wraps **any** UUID-shaped string as an OVSDB uuid atom `["uuid", …]`, including string values inside a `map` (e.g. `external_ids`, which is `map<string,string>`). A UUID-valued entry such as `vm-id` then serializes as a uuid atom, and ovsdb-server rejects the transaction:

```
insert Logical_Switch_Port ... external_ids ... ["vm-id",["uuid","02414BB6-…"]]
→ {"error":"syntax error","details":"expected string"}
```

### Change
In the map branch of `convertToJSONValue`, encode `String` values directly as `.string(...)` (non-string values still go through `convertToJSONValue`). Applied to both `OVNManager` and `OVSManager`.

### Verified
With this fix the `Logical_Switch_Port` insert succeeds, the VM's TAP port attaches to the integration bridge, and the VM boots end-to-end.

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)