### PR TITLE
Attach logical switch ports to their switch atomically (fixes #11)

### DIFF
--- a/Examples/BasicUsage.swift
+++ b/Examples/BasicUsage.swift
@@ -71,8 +71,8 @@ struct BasicUsageExample {
                 external_ids: ["vm": "vm2", "tenant": "demo"]
             )
 
-            let port1UUID = try await ovnManager.createLogicalSwitchPort(port1)
-            let port2UUID = try await ovnManager.createLogicalSwitchPort(port2)
+            let port1UUID = try await ovnManager.createLogicalSwitchPort(port1, onSwitch: "example-switch")
+            let port2UUID = try await ovnManager.createLogicalSwitchPort(port2, onSwitch: "example-switch")
 
             print("✅ Created ports: \(port1UUID), \(port2UUID)")
 

--- a/Sources/SwiftOVN/Core/OVSDBConnection.swift
+++ b/Sources/SwiftOVN/Core/OVSDBConnection.swift
@@ -164,11 +164,21 @@ public actor OVSDBConnection {
         )
         
         let results = try await client.transact(database: database, operations: [operation])
-        
+
         guard let firstResult = results.first else {
             throw OVNManagerError.invalidResponse("No result from insert operation")
         }
-        
+
+        // Check if there's an error in the response
+        if case .object(let resultObject) = firstResult,
+           let error = resultObject["error"], case .string(let errorMessage) = error {
+            var message = "Insert operation failed: \(errorMessage)"
+            if case .string(let details)? = resultObject["details"] {
+                message += " (\(details))"
+            }
+            throw OVNManagerError.operationFailed(message)
+        }
+
         return firstResult
     }
     
@@ -252,14 +262,22 @@ public actor OVSDBConnection {
         )
         
         let results = try await client.transact(database: database, operations: [operation])
-        
+
         guard let firstResult = results.first,
-              case .object(let resultObject) = firstResult,
-              let count = resultObject["count"],
-              case .number(let countValue) = count else {
+              case .object(let resultObject) = firstResult else {
             throw OVNManagerError.invalidResponse("Invalid mutate response format")
         }
-        
+
+        // Check if there's an error in the response
+        if let error = resultObject["error"], case .string(let errorMessage) = error {
+            throw OVNManagerError.operationFailed("Mutate operation failed: \(errorMessage)")
+        }
+
+        guard let count = resultObject["count"],
+              case .number(let countValue) = count else {
+            throw OVNManagerError.invalidResponse("Invalid mutate response format: missing count field")
+        }
+
         return Int(countValue)
     }
     

--- a/Sources/SwiftOVN/Core/OVSDBConnection.swift
+++ b/Sources/SwiftOVN/Core/OVSDBConnection.swift
@@ -60,6 +60,30 @@ public actor OVSDBConnection {
     }
     
     // MARK: - Table Operations
+
+    /// Executes multiple operations in a single OVSDB transaction and returns
+    /// the per-operation results. Throws if any operation reports an error —
+    /// ovsdb-server returns operation errors inside a successful JSON-RPC
+    /// response (RFC 7047 §4.1.3), so callers cannot rely on the RPC layer
+    /// alone to detect a failed/aborted transaction.
+    public func transact(in database: String, operations: [OVSDBOperation]) async throws -> [JSONValue] {
+        let results = try await client.transact(database: database, operations: operations)
+
+        for (index, result) in results.enumerated() {
+            guard case .object(let resultObject) = result,
+                  let error = resultObject["error"],
+                  case .string(let errorName) = error else {
+                continue
+            }
+            var message = "Transaction operation \(index) failed: \(errorName)"
+            if case .string(let details)? = resultObject["details"] {
+                message += " (\(details))"
+            }
+            throw OVNManagerError.operationFailed(message)
+        }
+
+        return results
+    }
     
     public func selectAll(from table: String, in database: String, columns: [String]? = nil) async throws -> [OVSDBRow] {
         let operation = OVSDBOperation(

--- a/Sources/SwiftOVN/Managers/OVNManager.swift
+++ b/Sources/SwiftOVN/Managers/OVNManager.swift
@@ -63,12 +63,13 @@ public actor OVNManager: OVNManaging {
     }
     
     public func createLogicalSwitch(_ logicalSwitch: OVNLogicalSwitch) async throws -> String {
-        guard try await getLogicalSwitch(named: logicalSwitch.name) == nil else {
+        let nameCondition = OVSDBCondition(column: "name", function: "==", value: .string(logicalSwitch.name))
+
+        guard try await rowUUID(in: OVNTable.logicalSwitch, where: nameCondition) == nil else {
             throw OVNManagerError.operationFailed("Logical switch already exists: \(logicalSwitch.name)")
         }
 
         let row = try createRow(from: logicalSwitch)
-        let nameCondition = OVSDBCondition(column: "name", function: "==", value: .string(logicalSwitch.name))
 
         // The NB schema doesn't enforce unique switch names, so guard against
         // a duplicate racing in between the check above and the insert: abort
@@ -180,12 +181,13 @@ public actor OVNManager: OVNManaging {
     /// A port whose UUID is not referenced by `Logical_Switch.ports` is an
     /// orphan that ovn-northd ignores, so the two steps must never diverge.
     public func createLogicalSwitchPort(_ port: OVNLogicalSwitchPort, onSwitch switchName: String) async throws -> String {
-        guard try await getLogicalSwitch(named: switchName) != nil else {
+        let switchCondition = OVSDBCondition(column: "name", function: "==", value: .string(switchName))
+
+        guard try await rowUUID(in: OVNTable.logicalSwitch, where: switchCondition) != nil else {
             throw OVNManagerError.operationFailed("Logical switch not found: \(switchName)")
         }
 
         let row = try createRow(from: port)
-        let switchCondition = OVSDBCondition(column: "name", function: "==", value: .string(switchName))
         let portUUIDName = "new_lsp"
 
         let operations = [
@@ -283,7 +285,8 @@ public actor OVNManager: OVNManaging {
     }
 
     public func deleteLogicalSwitchPort(named name: String) async throws {
-        guard let port = try await getLogicalSwitchPort(named: name), let uuid = port.uuid else {
+        let condition = OVSDBCondition(column: "name", function: "==", value: .string(name))
+        guard let uuid = try await rowUUID(in: OVNTable.logicalSwitchPort, where: condition) else {
             throw OVNManagerError.operationFailed("Logical switch port not found: \(name)")
         }
 
@@ -725,6 +728,21 @@ public actor OVNManager: OVNManaging {
 // MARK: - Helper Methods
 
 private extension OVNManager {
+    /// Looks up a row's _uuid via a narrow select, avoiding full-row model
+    /// decoding (which currently chokes on OVSDB's bare-atom/empty-set
+    /// representations for some columns). Returns nil when no row matches.
+    func rowUUID(in table: String, where condition: OVSDBCondition) async throws -> String? {
+        let rows = try await connection.select(from: table, in: database, where: [condition], columns: ["_uuid"])
+
+        guard let row = rows.first else { return nil }
+        guard case .array(let uuidArray)? = row["_uuid"],
+              uuidArray.count == 2,
+              case .string(let uuidValue) = uuidArray[1] else {
+            throw OVNManagerError.invalidResponse("Invalid _uuid in select response")
+        }
+        return uuidValue
+    }
+
     func parseRow<T: Codable>(_ row: OVSDBRow, as type: T.Type) throws -> T {
         let jsonObject = convertRowToJSONObject(row)
         let data = try JSONSerialization.data(withJSONObject: jsonObject)

--- a/Sources/SwiftOVN/Managers/OVNManager.swift
+++ b/Sources/SwiftOVN/Managers/OVNManager.swift
@@ -63,17 +63,45 @@ public actor OVNManager: OVNManaging {
     }
     
     public func createLogicalSwitch(_ logicalSwitch: OVNLogicalSwitch) async throws -> String {
+        guard try await getLogicalSwitch(named: logicalSwitch.name) == nil else {
+            throw OVNManagerError.operationFailed("Logical switch already exists: \(logicalSwitch.name)")
+        }
+
         let row = try createRow(from: logicalSwitch)
-        let result = try await connection.insert(into: OVNTable.logicalSwitch, in: database, row: row)
-        
-        guard case .object(let resultObject) = result,
-              let uuid = resultObject["uuid"],
+        let nameCondition = OVSDBCondition(column: "name", function: "==", value: .string(logicalSwitch.name))
+
+        // The NB schema doesn't enforce unique switch names, so guard against
+        // a duplicate racing in between the check above and the insert: abort
+        // the transaction unless no row with this name exists (the same
+        // technique ovn-nbctl ls-add uses to refuse duplicates).
+        let operations = [
+            OVSDBOperation(
+                op: "wait",
+                table: OVNTable.logicalSwitch,
+                whereConditions: [nameCondition],
+                columns: ["name"],
+                rows: [],
+                until: "==",
+                timeout: 0
+            ),
+            OVSDBOperation(
+                op: "insert",
+                table: OVNTable.logicalSwitch,
+                row: row
+            )
+        ]
+
+        let results = try await connection.transact(in: database, operations: operations)
+
+        guard results.count >= 2,
+              case .object(let insertResult) = results[1],
+              let uuid = insertResult["uuid"],
               case .array(let uuidArray) = uuid,
               uuidArray.count == 2,
               case .string(let uuidValue) = uuidArray[1] else {
             throw OVNManagerError.invalidResponse("Invalid UUID in insert response")
         }
-        
+
         logger.info("Created logical switch: \(logicalSwitch.name)")
         return uuidValue
     }

--- a/Sources/SwiftOVN/Managers/OVNManager.swift
+++ b/Sources/SwiftOVN/Managers/OVNManager.swift
@@ -130,10 +130,11 @@ public actor OVNManager: OVNManaging {
         return try parseRow(firstRow, as: OVNLogicalSwitchPort.self)
     }
     
+    @available(*, deprecated, message: "Creates an orphan row that ovn-northd ignores (no Port_Binding, no dataplane). Use createLogicalSwitchPort(_:onSwitch:) so the port is attached to its switch.")
     public func createLogicalSwitchPort(_ port: OVNLogicalSwitchPort) async throws -> String {
         let row = try createRow(from: port)
         let result = try await connection.insert(into: OVNTable.logicalSwitchPort, in: database, row: row)
-        
+
         guard case .object(let resultObject) = result,
               let uuid = resultObject["uuid"],
               case .array(let uuidArray) = uuid,
@@ -141,8 +142,67 @@ public actor OVNManager: OVNManaging {
               case .string(let uuidValue) = uuidArray[1] else {
             throw OVNManagerError.invalidResponse("Invalid UUID in insert response")
         }
-        
+
         logger.info("Created logical switch port: \(port.name)")
+        return uuidValue
+    }
+
+    /// Creates a logical switch port and attaches it to the named logical
+    /// switch in a single OVSDB transaction, mirroring `ovn-nbctl lsp-add`.
+    /// A port whose UUID is not referenced by `Logical_Switch.ports` is an
+    /// orphan that ovn-northd ignores, so the two steps must never diverge.
+    public func createLogicalSwitchPort(_ port: OVNLogicalSwitchPort, onSwitch switchName: String) async throws -> String {
+        guard try await getLogicalSwitch(named: switchName) != nil else {
+            throw OVNManagerError.operationFailed("Logical switch not found: \(switchName)")
+        }
+
+        let row = try createRow(from: port)
+        let switchCondition = OVSDBCondition(column: "name", function: "==", value: .string(switchName))
+        let portUUIDName = "new_lsp"
+
+        let operations = [
+            // Guard: abort the whole transaction if the switch vanished
+            // between the check above and this transaction, so the insert
+            // below can never commit as an orphan.
+            OVSDBOperation(
+                op: "wait",
+                table: OVNTable.logicalSwitch,
+                whereConditions: [switchCondition],
+                columns: ["name"],
+                rows: [["name": .string(switchName)]],
+                until: "==",
+                timeout: 0
+            ),
+            OVSDBOperation(
+                op: "insert",
+                table: OVNTable.logicalSwitchPort,
+                row: row,
+                uuidName: portUUIDName
+            ),
+            OVSDBOperation(
+                op: "mutate",
+                table: OVNTable.logicalSwitch,
+                whereConditions: [switchCondition],
+                mutations: [OVSDBMutation(
+                    column: "ports",
+                    mutator: "insert",
+                    value: .array([.string("named-uuid"), .string(portUUIDName)])
+                )]
+            )
+        ]
+
+        let results = try await connection.transact(in: database, operations: operations)
+
+        guard results.count >= 2,
+              case .object(let insertResult) = results[1],
+              let uuid = insertResult["uuid"],
+              case .array(let uuidArray) = uuid,
+              uuidArray.count == 2,
+              case .string(let uuidValue) = uuidArray[1] else {
+            throw OVNManagerError.invalidResponse("Invalid UUID in insert response")
+        }
+
+        logger.info("Created logical switch port: \(port.name) on switch: \(switchName)")
         return uuidValue
     }
     
@@ -160,24 +220,47 @@ public actor OVNManager: OVNManaging {
     }
     
     public func deleteLogicalSwitchPort(uuid: String) async throws {
-        let condition = OVSDBCondition(column: "_uuid", function: "==", value: .array([.string("uuid"), .string(uuid)]))
-        let count = try await connection.delete(from: OVNTable.logicalSwitchPort, in: database, where: [condition])
-        
-        if count == 0 {
+        let uuidAtom = JSONValue.array([.string("uuid"), .string(uuid)])
+
+        let operations = [
+            // Detach the port from any switch referencing it, in the same
+            // transaction as the row delete, so no dangling UUID is left in
+            // Logical_Switch.ports. Matching zero switches is fine (orphan).
+            OVSDBOperation(
+                op: "mutate",
+                table: OVNTable.logicalSwitch,
+                whereConditions: [OVSDBCondition(column: "ports", function: "includes", value: uuidAtom)],
+                mutations: [OVSDBMutation(column: "ports", mutator: "delete", value: uuidAtom)]
+            ),
+            OVSDBOperation(
+                op: "delete",
+                table: OVNTable.logicalSwitchPort,
+                whereConditions: [OVSDBCondition(column: "_uuid", function: "==", value: uuidAtom)]
+            )
+        ]
+
+        let results = try await connection.transact(in: database, operations: operations)
+
+        guard results.count >= 2,
+              case .object(let deleteResult) = results[1],
+              case .number(let count)? = deleteResult["count"] else {
+            throw OVNManagerError.invalidResponse("Invalid delete response format")
+        }
+
+        if Int(count) == 0 {
             throw OVNManagerError.operationFailed("Logical switch port not found: \(uuid)")
         }
-        
+
         logger.info("Deleted logical switch port: \(uuid)")
     }
-    
+
     public func deleteLogicalSwitchPort(named name: String) async throws {
-        let condition = OVSDBCondition(column: "name", function: "==", value: .string(name))
-        let count = try await connection.delete(from: OVNTable.logicalSwitchPort, in: database, where: [condition])
-        
-        if count == 0 {
+        guard let port = try await getLogicalSwitchPort(named: name), let uuid = port.uuid else {
             throw OVNManagerError.operationFailed("Logical switch port not found: \(name)")
         }
-        
+
+        try await deleteLogicalSwitchPort(uuid: uuid)
+
         logger.info("Deleted logical switch port: \(name)")
     }
     

--- a/Sources/SwiftOVN/Models/OVSDBMutation.swift
+++ b/Sources/SwiftOVN/Models/OVSDBMutation.swift
@@ -10,4 +10,19 @@ public struct OVSDBMutation: Codable, Sendable {
         self.mutator = mutator
         self.value = value
     }
+
+    // OVSDB mutations must be encoded as arrays: [column, mutator, value]
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(column)
+        try container.encode(mutator)
+        try container.encode(value)
+    }
+
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        column = try container.decode(String.self)
+        mutator = try container.decode(String.self)
+        value = try container.decode(JSONValue.self)
+    }
 }

--- a/Sources/SwiftOVN/Models/OVSDBOperation.swift
+++ b/Sources/SwiftOVN/Models/OVSDBOperation.swift
@@ -8,13 +8,17 @@ public struct OVSDBOperation: Codable, Sendable {
     public let rows: [OVSDBRow]?
     public let row: OVSDBRow?
     public let mutations: [OVSDBMutation]?
-    
+    public let uuidName: String?
+    public let until: String?
+    public let timeout: Int?
+
     private enum CodingKeys: String, CodingKey {
-        case op, table, columns, rows, row, mutations
+        case op, table, columns, rows, row, mutations, until, timeout
         case whereConditions = "where"
+        case uuidName = "uuid-name"
     }
-    
-    public init(op: String, table: String, whereConditions: [OVSDBCondition]? = nil, columns: [String]? = nil, rows: [OVSDBRow]? = nil, row: OVSDBRow? = nil, mutations: [OVSDBMutation]? = nil) {
+
+    public init(op: String, table: String, whereConditions: [OVSDBCondition]? = nil, columns: [String]? = nil, rows: [OVSDBRow]? = nil, row: OVSDBRow? = nil, mutations: [OVSDBMutation]? = nil, uuidName: String? = nil, until: String? = nil, timeout: Int? = nil) {
         self.op = op
         self.table = table
         self.whereConditions = whereConditions
@@ -22,5 +26,8 @@ public struct OVSDBOperation: Codable, Sendable {
         self.rows = rows
         self.row = row
         self.mutations = mutations
+        self.uuidName = uuidName
+        self.until = until
+        self.timeout = timeout
     }
 }

--- a/Sources/SwiftOVN/Protocols/OVNManaging.swift
+++ b/Sources/SwiftOVN/Protocols/OVNManaging.swift
@@ -25,7 +25,9 @@ public protocol OVNManaging {
     // Logical Switch Port Operations
     func getLogicalSwitchPorts() async throws -> [OVNLogicalSwitchPort]
     func getLogicalSwitchPort(named name: String) async throws -> OVNLogicalSwitchPort?
+    @available(*, deprecated, message: "Creates an orphan row that ovn-northd ignores (no Port_Binding, no dataplane). Use createLogicalSwitchPort(_:onSwitch:) so the port is attached to its switch.")
     func createLogicalSwitchPort(_ port: OVNLogicalSwitchPort) async throws -> String
+    func createLogicalSwitchPort(_ port: OVNLogicalSwitchPort, onSwitch switchName: String) async throws -> String
     func updateLogicalSwitchPort(uuid: String, _ port: OVNLogicalSwitchPort) async throws
     func deleteLogicalSwitchPort(uuid: String) async throws
     func deleteLogicalSwitchPort(named name: String) async throws

--- a/Tests/SwiftOVNTests/OVNManagerTests.swift
+++ b/Tests/SwiftOVNTests/OVNManagerTests.swift
@@ -240,6 +240,70 @@ final class JSONRPCClientMockTests: XCTestCase {
         XCTAssertEqual(decodedOperation.columns, operation.columns)
     }
     
+    func testOVSDBConditionEncodesAsArray() throws {
+        let condition = OVSDBCondition(column: "name", function: "==", value: .string("ls0"))
+
+        let data = try JSONEncoder().encode(condition)
+        let json = try JSONSerialization.jsonObject(with: data)
+
+        XCTAssertEqual(json as? [String], ["name", "==", "ls0"])
+    }
+
+    func testOVSDBMutationEncodesAsArray() throws {
+        // RFC 7047 requires mutations on the wire as [column, mutator, value],
+        // not a keyed object — ovsdb-server rejects the object form.
+        let mutation = OVSDBMutation(
+            column: "ports",
+            mutator: "insert",
+            value: .array([.string("named-uuid"), .string("new_lsp")])
+        )
+
+        let data = try JSONEncoder().encode(mutation)
+        let json = try JSONSerialization.jsonObject(with: data)
+
+        guard let array = json as? [Any], array.count == 3 else {
+            return XCTFail("Expected 3-element array, got \(json)")
+        }
+        XCTAssertEqual(array[0] as? String, "ports")
+        XCTAssertEqual(array[1] as? String, "insert")
+        XCTAssertEqual(array[2] as? [String], ["named-uuid", "new_lsp"])
+
+        let decoded = try JSONDecoder().decode(OVSDBMutation.self, from: data)
+        XCTAssertEqual(decoded.column, mutation.column)
+        XCTAssertEqual(decoded.mutator, mutation.mutator)
+        XCTAssertEqual(decoded.value, mutation.value)
+    }
+
+    func testOVSDBOperationEncodesUUIDNameAndWaitFields() throws {
+        let insert = OVSDBOperation(
+            op: "insert",
+            table: "Logical_Switch_Port",
+            row: ["name": .string("vm1-port")],
+            uuidName: "new_lsp"
+        )
+
+        let insertJSON = try JSONSerialization.jsonObject(with: JSONEncoder().encode(insert)) as? [String: Any]
+        XCTAssertEqual(insertJSON?["uuid-name"] as? String, "new_lsp")
+        XCTAssertNil(insertJSON?["uuidName"])
+        XCTAssertNil(insertJSON?["where"], "insert must not carry a where clause")
+
+        let wait = OVSDBOperation(
+            op: "wait",
+            table: "Logical_Switch",
+            whereConditions: [OVSDBCondition(column: "name", function: "==", value: .string("ls0"))],
+            columns: ["name"],
+            rows: [["name": .string("ls0")]],
+            until: "==",
+            timeout: 0
+        )
+
+        let waitJSON = try JSONSerialization.jsonObject(with: JSONEncoder().encode(wait)) as? [String: Any]
+        XCTAssertEqual(waitJSON?["until"] as? String, "==")
+        XCTAssertEqual(waitJSON?["timeout"] as? Int, 0)
+        XCTAssertEqual((waitJSON?["rows"] as? [[String: Any]])?.first?["name"] as? String, "ls0")
+        XCTAssertEqual((waitJSON?["where"] as? [[Any]])?.count, 1)
+    }
+
     func testMonitorRequestSerialization() throws {
         let monitorRequest = OVSDBMonitorRequest(
             columns: ["name", "ports"],


### PR DESCRIPTION
Fixes #11.

## What

`createLogicalSwitchPort` inserted the LSP row but never referenced it from `Logical_Switch.ports`, leaving an orphan that ovn-northd ignores: no `Port_Binding`, no flows, no dataplane.

- **New `createLogicalSwitchPort(_:onSwitch:)`** — in a single OVSDB transaction: a `wait` op guards on the switch's existence (so the insert aborts instead of orphaning if the switch vanished), the LSP is inserted with a named-uuid, and the switch's `ports` set is mutated to reference it. This mirrors `ovn-nbctl lsp-add`. The old no-switch signature is kept but deprecated.
- **Symmetric delete** — `deleteLogicalSwitchPort` now removes the port's UUID from any referencing switch in the same transaction as the row delete, so no dangling references are left behind.
- **`createLogicalSwitch` refuses duplicates** — the NB schema doesn't enforce unique switch names, which is how the three `switch (net0)` rows from the issue accumulated. Creation now errors if the name exists, with a wait-op guard against racing creates (same technique as `ovn-nbctl ls-add`).

## Bugs this surfaced along the way

- **`OVSDBMutation` violated RFC 7047**: it encoded as a keyed JSON object instead of the required `[column, mutator, value]` array, so every `mutate` operation the library ever sent would have been rejected by ovsdb-server. Fixed with a custom unkeyed encoder (same as `OVSDBCondition` already did).
- **Op-level errors were swallowed**: ovsdb-server reports per-operation errors *inside* a successful JSON-RPC response. `insert`/`mutate` now surface `error`/`details` instead of masking constraint violations as `"Invalid UUID in insert response"`.
- **Infrastructure**: `OVSDBOperation` gains `uuid-name`, `until`, and `timeout` fields; `OVSDBConnection` gains a multi-op `transact(in:operations:)` that checks per-op errors.
- The new lookup pre-checks select only `_uuid` rather than decoding full model rows, since the synthesized decoders currently throw on OVSDB bare-atom / empty-set representations (e.g. a switch with exactly one port).

## Tests

Added wire-format tests asserting the RFC 7047 encodings (condition/mutation arrays, `uuid-name`, wait-op fields). `swift test`: 28/28 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)