### PR TITLE
Rework inbound JSON-RPC routing so database monitoring works end-to-end

### DIFF
--- a/Sources/SwiftOVN/Core/JSONRPCClient.swift
+++ b/Sources/SwiftOVN/Core/JSONRPCClient.swift
@@ -160,43 +160,41 @@ public actor JSONRPCClient {
     
     public func cancelMonitor(monitorId: String) async throws {
         let params = JSONRPCParams.array([.string(monitorId)])
-        
-        try await notify(method: "monitor_cancel", params: params)
+
+        // RFC 7047 §4.1.7: monitor_cancel is a request; the server replies
+        // with an empty result once the monitor is torn down.
+        _ = try await call(
+            method: "monitor_cancel",
+            params: params,
+            responseType: JSONValue.self
+        )
     }
-    
+
     // MARK: - Monitoring Stream
-    
+
+    /// Streams `update` notifications as `(monitorId, tableUpdates)` pairs.
+    ///
+    /// Subscribe *before* calling `monitor(...)` so no update is missed; the
+    /// underlying stream buffers notifications between iterations. The stream
+    /// has no idle timeout — it lives until the connection closes or the
+    /// consumer cancels.
     nonisolated public func monitorUpdates() -> AsyncThrowingStream<(String, JSONValue), Error> {
-        AsyncThrowingStream { continuation in
-            Task {
-                while connection.isConnectionActive {
-                    do {
-                        let response: JSONRPCResponse<JSONValue> = try await connection.receiveAny(
-                            as: JSONRPCResponse<JSONValue>.self,
-                            timeout: .seconds(60)
-                        ).get()
-                        
-                        if let result = response.result, 
-                           case .object(let updateObject) = result,
-                           let method = updateObject["method"],
-                           case .string(let methodName) = method,
-                           methodName == "update" {
-                            
-                            if let params = updateObject["params"],
-                               case .array(let paramsArray) = params,
-                               paramsArray.count >= 2,
-                               case .string(let monitorId) = paramsArray[0] {
-                                continuation.yield((monitorId, paramsArray[1]))
-                            }
-                        }
-                    } catch {
-                        if connection.isConnectionActive {
-                            continuation.finish(throwing: error)
-                        }
-                        break
+        let notifications = connection.notifications()
+        return AsyncThrowingStream { continuation in
+            let task = Task {
+                for await notification in notifications {
+                    guard notification.method == "update",
+                          case .array(let paramsArray)? = notification.params,
+                          paramsArray.count >= 2,
+                          case .string(let monitorId) = paramsArray[0] else {
+                        continue
                     }
+                    continuation.yield((monitorId, paramsArray[1]))
                 }
                 continuation.finish()
+            }
+            continuation.onTermination = { _ in
+                task.cancel()
             }
         }
     }

--- a/Sources/SwiftOVN/Core/OVSDBConnection.swift
+++ b/Sources/SwiftOVN/Core/OVSDBConnection.swift
@@ -241,14 +241,20 @@ public actor OVSDBConnection {
     
     // MARK: - Monitoring
     
+    /// Starts a monitor and returns its ID together with the initial database
+    /// contents (the monitor reply carries one insert-style update per
+    /// existing row when `select.initial` is requested).
+    ///
+    /// To observe subsequent changes without missing any, create the
+    /// `monitorUpdates()` stream *before* calling this method.
     public func startMonitoring(
         database: String,
         tables: [String: OVSDBMonitorRequest],
         monitorId: String? = nil
-    ) async throws -> String {
+    ) async throws -> (monitorId: String, initialUpdates: [OVSDBUpdate]) {
         let id = monitorId ?? UUID().uuidString
 
-        _ = try await client.monitor(
+        let initialState = try await client.monitor(
             database: database,
             monitorId: id,
             requests: tables
@@ -256,9 +262,11 @@ public actor OVSDBConnection {
 
         activeMonitors.insert(id)
 
-        logger.info("Started monitoring database \(database) with ID: \(id)")
+        let initialUpdates = Self.parseTableUpdates(initialState)
 
-        return id
+        logger.info("Started monitoring database \(database) with ID: \(id) (\(initialUpdates.count) initial rows)")
+
+        return (monitorId: id, initialUpdates: initialUpdates)
     }
     
     public func stopMonitoring(monitorId: String) async throws {
@@ -269,39 +277,59 @@ public actor OVSDBConnection {
         logger.info("Stopped monitoring with ID: \(monitorId)")
     }
     
-    nonisolated public func monitorUpdates() -> AsyncThrowingStream<OVSDBUpdate, Error> {
+    /// Streams row changes from all monitors on this connection, optionally
+    /// filtered to a single monitor ID.
+    ///
+    /// Create the stream *before* calling `startMonitoring` so no update is
+    /// missed; updates are buffered while the consumer is between iterations.
+    /// The stream lives until the connection closes or the consumer cancels.
+    nonisolated public func monitorUpdates(monitorId: String? = nil) -> AsyncThrowingStream<OVSDBUpdate, Error> {
+        let clientStream = client.monitorUpdates()
         return AsyncThrowingStream { continuation in
-            Task {
-                let clientStream = client.monitorUpdates()
+            let task = Task {
                 do {
-                    for try await (_, updateValue) in clientStream {
-                        // Parse the update value into OVSDBUpdate format
-                        if case .object(let updateObject) = updateValue {
-                            for (_, tableUpdate) in updateObject {
-                                if case .object(let tableUpdateObject) = tableUpdate {
-                                    for (_, rowUpdate) in tableUpdateObject {
-                                        if case .object(let rowUpdateObject) = rowUpdate {
-                                            let old = rowUpdateObject["old"].flatMap { value in
-                                                if case .object(let obj) = value { return obj }
-                                                return nil
-                                            }
-                                            let new = rowUpdateObject["new"].flatMap { value in
-                                                if case .object(let obj) = value { return obj }
-                                                return nil
-                                            }
-                                            
-                                            let update = OVSDBUpdate(old: old, new: new)
-                                            continuation.yield(update)
-                                        }
-                                    }
-                                }
-                            }
+                    for try await (id, tableUpdates) in clientStream {
+                        if let monitorId, monitorId != id {
+                            continue
+                        }
+                        for update in Self.parseTableUpdates(tableUpdates) {
+                            continuation.yield(update)
                         }
                     }
+                    continuation.finish()
                 } catch {
                     continuation.finish(throwing: error)
                 }
             }
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
         }
+    }
+
+    /// Parses an RFC 7047 table-updates object
+    /// (`{table: {row-uuid: {"old": ..., "new": ...}}}`) into row updates.
+    static func parseTableUpdates(_ value: JSONValue) -> [OVSDBUpdate] {
+        guard case .object(let tables) = value else {
+            return []
+        }
+
+        var updates: [OVSDBUpdate] = []
+        for (tableName, tableValue) in tables {
+            guard case .object(let rows) = tableValue else { continue }
+            for (rowUUID, rowValue) in rows {
+                guard case .object(let rowUpdate) = rowValue else { continue }
+                let old = rowUpdate["old"].flatMap { value -> OVSDBRow? in
+                    if case .object(let obj) = value { return obj }
+                    return nil
+                }
+                let new = rowUpdate["new"].flatMap { value -> OVSDBRow? in
+                    if case .object(let obj) = value { return obj }
+                    return nil
+                }
+                updates.append(OVSDBUpdate(table: tableName, uuid: rowUUID, old: old, new: new))
+            }
+        }
+        return updates
     }
 }

--- a/Sources/SwiftOVN/Core/UnixSocketConnection.swift
+++ b/Sources/SwiftOVN/Core/UnixSocketConnection.swift
@@ -11,14 +11,15 @@ public final class UnixSocketConnection: @unchecked Sendable {
     private var isConnected: Bool = false
     private var responseRouter: JSONRPCResponseRouter?
     private let connectionLock = NSLock()
-    
+    private let notificationHub = JSONRPCNotificationHub()
+
     public init(socketPath: String, eventLoopGroup: EventLoopGroup? = nil, logger: Logger? = nil) {
         self.socketPath = socketPath
         self.eventLoopGroup = eventLoopGroup ?? MultiThreadedEventLoopGroup(numberOfThreads: 1)
         self.logger = logger ?? Logger(label: "ovn-manager.unix-socket")
     }
-    
-    
+
+
     public func connect() -> EventLoopFuture<Void> {
         connectionLock.lock()
         let alreadyConnected = isConnected
@@ -28,23 +29,27 @@ public final class UnixSocketConnection: @unchecked Sendable {
             logger.debug("Already connected to Unix socket")
             return eventLoopGroup.next().makeSucceededFuture(())
         }
-        
+
         logger.info("Connecting to Unix socket at: \(socketPath)")
         logger.debug("Checking if socket file exists...")
-        
+
         // Check if socket file exists
         if !FileManager.default.fileExists(atPath: socketPath) {
             logger.error("Socket file does not exist at path: \(socketPath)")
             return eventLoopGroup.next().makeFailedFuture(OVNManagerError.connectionFailed("Socket file not found: \(socketPath)"))
         }
-        
+
         logger.debug("Socket file exists, creating bootstrap...")
-        
+
         let bootstrap = ClientBootstrap(group: eventLoopGroup)
             .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .channelInitializer { channel in
                 self.logger.debug("Initializing channel pipeline...")
-                let router = JSONRPCResponseRouter(logger: self.logger, eventLoopGroup: self.eventLoopGroup)
+                let router = JSONRPCResponseRouter(
+                    logger: self.logger,
+                    eventLoopGroup: self.eventLoopGroup,
+                    notificationHub: self.notificationHub
+                )
                 self.responseRouter = router
                 return channel.pipeline.addHandlers([
                     ByteToMessageHandler(OVSDBJSONFrameDecoder()),
@@ -57,9 +62,9 @@ public final class UnixSocketConnection: @unchecked Sendable {
                     return channel.eventLoop.makeFailedFuture(error)
                 }
             }
-        
+
         logger.debug("Attempting to connect to Unix domain socket...")
-        
+
         return bootstrap.connect(unixDomainSocketPath: socketPath)
             .map { channel in
                 self.logger.debug("Raw connection established, setting up channel...")
@@ -79,7 +84,7 @@ public final class UnixSocketConnection: @unchecked Sendable {
                 return self.eventLoopGroup.next().makeFailedFuture(OVNManagerError.connectionFailed("Failed to connect to \(self.socketPath): \(error)"))
             }
     }
-    
+
     public func disconnect() -> EventLoopFuture<Void> {
         connectionLock.lock()
         guard let channel = channel, isConnected else {
@@ -92,6 +97,8 @@ public final class UnixSocketConnection: @unchecked Sendable {
         self.responseRouter = nil
         connectionLock.unlock()
 
+        // Closing the channel fires channelInactive on the router, which fails
+        // all in-flight requests and finishes the notification streams.
         return channel.close().map {
             self.connectionLock.lock()
             self.channel = nil
@@ -99,7 +106,7 @@ public final class UnixSocketConnection: @unchecked Sendable {
             self.logger.info("Successfully disconnected from Unix socket")
         }
     }
-    
+
     public func send<T: Codable>(_ message: T) -> EventLoopFuture<Void> {
         connectionLock.lock()
         guard let channel = channel, isConnected else {
@@ -109,7 +116,7 @@ public final class UnixSocketConnection: @unchecked Sendable {
             )
         }
         connectionLock.unlock()
-        
+
         do {
             let encoder = Foundation.JSONEncoder()
             let data = try encoder.encode(message)
@@ -118,7 +125,7 @@ public final class UnixSocketConnection: @unchecked Sendable {
                     NSError(domain: "UnixSocketConnection", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to convert data to string"])
                 )
             }
-            
+
             logger.debug("Sending message: \(jsonString)")
             return channel.writeAndFlush(jsonString + "\n")
         } catch {
@@ -126,7 +133,7 @@ public final class UnixSocketConnection: @unchecked Sendable {
             return eventLoopGroup.next().makeFailedFuture(OVNManagerError.encodingError(error))
         }
     }
-    
+
     public func receive<T: Codable>(as type: T.Type, requestId: JSONRPCIdentifier, timeout: TimeAmount = .seconds(30)) -> EventLoopFuture<T> {
         connectionLock.lock()
         guard let responseRouter = responseRouter, isConnected else {
@@ -139,21 +146,20 @@ public final class UnixSocketConnection: @unchecked Sendable {
 
         return responseRouter.waitForResponse(requestId: requestId, type: T.self, timeout: timeout)
     }
-    
-    // For monitoring - receives any message without filtering by request ID
-    public func receiveAny<T: Codable>(as type: T.Type, timeout: TimeAmount = .seconds(30)) -> EventLoopFuture<T> {
-        connectionLock.lock()
-        guard let responseRouter = responseRouter, isConnected else {
-            connectionLock.unlock()
-            return eventLoopGroup.next().makeFailedFuture(
-                OVNManagerError.connectionFailed("Not connected to socket")
-            )
-        }
-        connectionLock.unlock()
 
-        return responseRouter.waitForAnyResponse(type: T.self, timeout: timeout)
+    /// Returns a buffered stream of server-initiated JSON-RPC notifications
+    /// (messages with a `method` and a null or absent `id`, e.g. `update`).
+    ///
+    /// The stream buffers notifications from the moment it is created, so
+    /// subscribe *before* issuing the request that triggers them (e.g.
+    /// `monitor`) and no notification is lost even while the consumer is busy.
+    /// The stream finishes when the connection closes. Subscribing is valid
+    /// before `connect()` and multiple subscribers each receive every
+    /// notification.
+    public func notifications() -> AsyncStream<JSONRPCNotification> {
+        return notificationHub.subscribe()
     }
-    
+
     public var isConnectionActive: Bool {
         connectionLock.lock()
         defer { connectionLock.unlock() }
@@ -161,72 +167,176 @@ public final class UnixSocketConnection: @unchecked Sendable {
     }
 }
 
+// MARK: - Notification Hub
+
+/// Fans server-initiated notifications out to any number of subscribers.
+///
+/// Each subscriber gets an unbounded `AsyncStream`, so notifications that
+/// arrive while the consumer is between iterations are buffered rather than
+/// dropped. Outlives the channel handler so subscriptions can be created
+/// before the connection is established.
+final class JSONRPCNotificationHub: @unchecked Sendable {
+    private let lock = NSLock()
+    private var subscribers: [UUID: AsyncStream<JSONRPCNotification>.Continuation] = [:]
+
+    func subscribe() -> AsyncStream<JSONRPCNotification> {
+        let id = UUID()
+        let (stream, continuation) = AsyncStream.makeStream(of: JSONRPCNotification.self)
+        continuation.onTermination = { [weak self] _ in
+            self?.removeSubscriber(id)
+        }
+        lock.lock()
+        subscribers[id] = continuation
+        lock.unlock()
+        return stream
+    }
+
+    func publish(_ notification: JSONRPCNotification) {
+        lock.lock()
+        let continuations = Array(subscribers.values)
+        lock.unlock()
+
+        for continuation in continuations {
+            continuation.yield(notification)
+        }
+    }
+
+    func finishAll() {
+        lock.lock()
+        let continuations = Array(subscribers.values)
+        subscribers.removeAll()
+        lock.unlock()
+
+        for continuation in continuations {
+            continuation.finish()
+        }
+    }
+
+    private func removeSubscriber(_ id: UUID) {
+        lock.lock()
+        subscribers.removeValue(forKey: id)
+        lock.unlock()
+    }
+}
+
 // MARK: - JSON-RPC Response Router
 
-private final class JSONRPCResponseRouter: ChannelInboundHandler, RemovableChannelHandler, @unchecked Sendable {
+/// Routes each inbound JSON-RPC message to the right consumer:
+///
+/// - Messages with a `method` and a real `id` are server-to-client *requests*.
+///   RFC 7047 §4.1.11 requires `echo` to be answered (ovsdb-server's
+///   inactivity probe closes the connection otherwise), so those are replied
+///   to inline.
+/// - Messages with a `method` and a null/absent `id` are *notifications*
+///   (`update` etc.) and are published to the notification hub.
+/// - Messages with an `id` and no `method` are *responses* to our requests
+///   and complete the matching pending promise.
+final class JSONRPCResponseRouter: ChannelInboundHandler, RemovableChannelHandler, @unchecked Sendable {
     typealias InboundIn = String
 
     private let logger: Logger
     private let decoder = Foundation.JSONDecoder()
-    private var pendingRequests: [JSONRPCIdentifier: Any] = [:]
-    private var anyResponseWaiters: [Any] = []
+    private var pendingRequests: [JSONRPCIdentifier: PendingRequestProtocol] = [:]
     private let lock = NSLock()
     private var eventLoop: EventLoop?
     private let eventLoopGroup: EventLoopGroup
-    
-    init(logger: Logger, eventLoopGroup: EventLoopGroup) {
+    private let notificationHub: JSONRPCNotificationHub
+
+    init(logger: Logger, eventLoopGroup: EventLoopGroup, notificationHub: JSONRPCNotificationHub) {
         self.logger = logger
         self.eventLoopGroup = eventLoopGroup
+        self.notificationHub = notificationHub
     }
-    
+
     func handlerAdded(context: ChannelHandlerContext) {
         eventLoop = context.eventLoop
     }
-    
+
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let message = unwrapInboundIn(data)
         logger.debug("Received raw message: \(message)")
-        
+
         guard let messageData = message.data(using: .utf8) else {
             logger.error("Failed to convert message to UTF-8 data")
             return
         }
-        
-        do {
-            // Parse the JSON to see what kind of message this is
-            if let jsonObject = try JSONSerialization.jsonObject(with: messageData, options: []) as? [String: Any] {
-                
-                // Check if this is a response (has an "id" field)
-                if let idValue = jsonObject["id"] {
-                    let responseId: JSONRPCIdentifier
-                    if let idNumber = idValue as? Int {
-                        responseId = .number(idNumber)
-                    } else if let idString = idValue as? String {
-                        responseId = .string(idString)
-                    } else {
-                        logger.debug("Received message with invalid ID type, ignoring")
-                        return
-                    }
-                    
-                    logger.debug("Processing response for request ID: \(responseId)")
-                    handleResponse(responseId: responseId, messageData: messageData)
-                } else {
-                    // No ID field - this might be a notification or monitoring update
-                    logger.debug("Received message without ID (likely notification), forwarding to any-response waiters")
-                    handleAnyResponse(messageData: messageData)
-                }
+
+        guard let jsonObject = (try? JSONSerialization.jsonObject(with: messageData, options: [])) as? [String: Any] else {
+            logger.error("Failed to parse inbound message as a JSON object")
+            return
+        }
+
+        let idValue = jsonObject["id"]
+        let hasRealId = idValue != nil && !(idValue is NSNull)
+
+        if let method = jsonObject["method"] as? String {
+            if hasRealId {
+                // Server-to-client request; a reply is expected.
+                handleServerRequest(context: context, method: method, jsonObject: jsonObject)
+            } else {
+                // JSON-RPC marks notifications with a null (or absent) id.
+                handleNotification(messageData: messageData, method: method)
             }
-        } catch {
-            logger.error("Failed to parse JSON message: \(error)")
+        } else if hasRealId {
+            let responseId: JSONRPCIdentifier
+            if let idNumber = idValue as? Int {
+                responseId = .number(idNumber)
+            } else if let idString = idValue as? String {
+                responseId = .string(idString)
+            } else {
+                logger.debug("Received response with unsupported ID type, ignoring")
+                return
+            }
+
+            logger.debug("Processing response for request ID: \(responseId)")
+            handleResponse(responseId: responseId, messageData: messageData)
+        } else {
+            logger.debug("Received message with neither method nor id, ignoring")
         }
     }
-    
+
+    private func handleServerRequest(context: ChannelHandlerContext, method: String, jsonObject: [String: Any]) {
+        guard method == "echo" else {
+            logger.warning("Received unsupported server-to-client request '\(method)', ignoring")
+            return
+        }
+
+        // RFC 7047 §4.1.11: the echo reply's result mirrors the request params.
+        let reply: [String: Any] = [
+            "id": jsonObject["id"] ?? NSNull(),
+            "result": jsonObject["params"] ?? [Any](),
+            "error": NSNull()
+        ]
+
+        do {
+            let data = try JSONSerialization.data(withJSONObject: reply)
+            guard let jsonString = String(data: data, encoding: .utf8) else {
+                logger.error("Failed to encode echo reply as UTF-8")
+                return
+            }
+            logger.debug("Replying to server echo request")
+            context.writeAndFlush(NIOAny(jsonString + "\n"), promise: nil)
+        } catch {
+            logger.error("Failed to serialize echo reply: \(error)")
+        }
+    }
+
+    private func handleNotification(messageData: Data, method: String) {
+        do {
+            let inbound = try decoder.decode(InboundNotificationMessage.self, from: messageData)
+            logger.debug("Dispatching notification: \(method)")
+            notificationHub.publish(JSONRPCNotification(method: inbound.method, params: inbound.params))
+        } catch {
+            logger.error("Failed to decode notification '\(method)': \(error)")
+        }
+    }
+
     private func handleResponse(responseId: JSONRPCIdentifier, messageData: Data) {
         lock.lock()
-        defer { lock.unlock() }
-        
-        if let pendingRequestAny = pendingRequests.removeValue(forKey: responseId),
-           let pendingRequest = pendingRequestAny as? PendingRequestProtocol {
+        let pendingRequest = pendingRequests.removeValue(forKey: responseId)
+        lock.unlock()
+
+        if let pendingRequest {
             logger.debug("Found matching pending request for ID: \(responseId)")
             pendingRequest.timeoutTask.cancel()
             pendingRequest.fulfill(with: messageData, decoder: decoder)
@@ -234,102 +344,70 @@ private final class JSONRPCResponseRouter: ChannelInboundHandler, RemovableChann
             logger.debug("No pending request found for response ID: \(responseId)")
         }
     }
-    
-    private func handleAnyResponse(messageData: Data) {
-        lock.lock()
-        let waiters = anyResponseWaiters
-        anyResponseWaiters.removeAll()
-        lock.unlock()
-        
-        for waiterAny in waiters {
-            if let waiter = waiterAny as? AnyResponseWaiterProtocol {
-                waiter.timeoutTask.cancel()
-                waiter.fulfill(with: messageData, decoder: decoder)
-            }
-        }
-    }
-    
+
     func waitForResponse<T: Codable>(requestId: JSONRPCIdentifier, type: T.Type, timeout: TimeAmount) -> EventLoopFuture<T> {
         guard let eventLoop = eventLoop else {
             let failedPromise = eventLoopGroup.next().makePromise(of: T.self)
             failedPromise.fail(OVNManagerError.connectionFailed("Event loop not available"))
             return failedPromise.futureResult
         }
-        
+
         let promise = eventLoop.makePromise(of: T.self)
-        
+
         let timeoutTask = eventLoop.scheduleTask(in: timeout) {
             self.lock.lock()
-            self.pendingRequests.removeValue(forKey: requestId)
+            let removed = self.pendingRequests.removeValue(forKey: requestId)
             self.lock.unlock()
-            promise.fail(OVNManagerError.timeoutError)
+            // Only fail if the request was still pending; a response may have
+            // already fulfilled the promise on another path.
+            if removed != nil {
+                promise.fail(OVNManagerError.timeoutError)
+            }
         }
-        
+
         let pendingRequest = PendingRequestWrapper<T>(
             promise: promise,
             timeoutTask: timeoutTask
         )
-        
+
         lock.lock()
         pendingRequests[requestId] = pendingRequest
         lock.unlock()
-        
+
         logger.debug("Added pending request for ID: \(requestId)")
-        
+
         return promise.futureResult
     }
-    
-    func waitForAnyResponse<T: Codable>(type: T.Type, timeout: TimeAmount) -> EventLoopFuture<T> {
-        guard let eventLoop = eventLoop else {
-            let failedPromise = eventLoopGroup.next().makePromise(of: T.self)
-            failedPromise.fail(OVNManagerError.connectionFailed("Event loop not available"))
-            return failedPromise.futureResult
-        }
-        
-        let promise = eventLoop.makePromise(of: T.self)
-        
-        let timeoutTask = eventLoop.scheduleTask(in: timeout) {
-            self.lock.lock()
-            defer { self.lock.unlock() }
-            promise.fail(OVNManagerError.timeoutError)
-        }
-        
-        let waiter = AnyResponseWaiterWrapper<T>(
-            promise: promise,
-            timeoutTask: timeoutTask
-        )
-        
-        lock.lock()
-        anyResponseWaiters.append(waiter)
-        lock.unlock()
-        
-        return promise.futureResult
+
+    func channelInactive(context: ChannelHandlerContext) {
+        logger.info("Channel became inactive, failing in-flight requests and finishing notification streams")
+        failAllPending(with: OVNManagerError.connectionFailed("Connection closed"))
+        notificationHub.finishAll()
+        context.fireChannelInactive()
     }
-    
+
     func errorCaught(context: ChannelHandlerContext, error: Error) {
         logger.error("Channel error caught: \(error)")
-        
+        failAllPending(with: error)
+        context.fireErrorCaught(error)
+    }
+
+    private func failAllPending(with error: Error) {
         lock.lock()
         let allPendingRequests = Array(pendingRequests.values)
-        let allWaiters = anyResponseWaiters
         pendingRequests.removeAll()
-        anyResponseWaiters.removeAll()
         lock.unlock()
-        
-        for requestAny in allPendingRequests {
-            if let request = requestAny as? PendingRequestProtocol {
-                request.timeoutTask.cancel()
-                request.fail(with: error)
-            }
-        }
-        
-        for waiterAny in allWaiters {
-            if let waiter = waiterAny as? AnyResponseWaiterProtocol {
-                waiter.timeoutTask.cancel()
-                waiter.fail(with: error)
-            }
+
+        for request in allPendingRequests {
+            request.timeoutTask.cancel()
+            request.fail(with: error)
         }
     }
+}
+
+private struct InboundNotificationMessage: Decodable {
+    let method: String
+    let params: JSONValue?
 }
 
 private protocol PendingRequestProtocol {
@@ -338,34 +416,10 @@ private protocol PendingRequestProtocol {
     func fail(with error: Error)
 }
 
-private protocol AnyResponseWaiterProtocol {
-    var timeoutTask: Scheduled<Void> { get }
-    func fulfill(with data: Data, decoder: JSONDecoder)
-    func fail(with error: Error)
-}
-
 private struct PendingRequestWrapper<T: Codable>: PendingRequestProtocol {
     let promise: EventLoopPromise<T>
     let timeoutTask: Scheduled<Void>
-    
-    func fulfill(with data: Data, decoder: JSONDecoder) {
-        do {
-            let response = try decoder.decode(T.self, from: data)
-            promise.succeed(response)
-        } catch {
-            promise.fail(OVNManagerError.decodingError(error))
-        }
-    }
-    
-    func fail(with error: Error) {
-        promise.fail(error)
-    }
-}
 
-private struct AnyResponseWaiterWrapper<T: Codable>: AnyResponseWaiterProtocol {
-    let promise: EventLoopPromise<T>
-    let timeoutTask: Scheduled<Void>
-    
     func fulfill(with data: Data, decoder: JSONDecoder) {
         do {
             let response = try decoder.decode(T.self, from: data)
@@ -374,7 +428,7 @@ private struct AnyResponseWaiterWrapper<T: Codable>: AnyResponseWaiterProtocol {
             promise.fail(OVNManagerError.decodingError(error))
         }
     }
-    
+
     func fail(with error: Error) {
         promise.fail(error)
     }
@@ -456,7 +510,7 @@ final class OVSDBJSONFrameDecoder: ByteToMessageDecoder, @unchecked Sendable {
 
 private final class StringToByteEncoder: MessageToByteEncoder, @unchecked Sendable {
     typealias OutboundIn = String
-    
+
     func encode(data: String, out: inout ByteBuffer) throws {
         out.writeString(data)
     }

--- a/Sources/SwiftOVN/Managers/OVNManager.swift
+++ b/Sources/SwiftOVN/Managers/OVNManager.swift
@@ -541,7 +541,7 @@ public actor OVNManager: OVNManaging {
             monitorRequests[table] = OVSDBMonitorRequest()
         }
         
-        return try await connection.startMonitoring(database: database, tables: monitorRequests)
+        return try await connection.startMonitoring(database: database, tables: monitorRequests).monitorId
     }
     
     public func stopMonitoring(monitorId: String) async throws {

--- a/Sources/SwiftOVN/Managers/OVSManager.swift
+++ b/Sources/SwiftOVN/Managers/OVSManager.swift
@@ -653,7 +653,7 @@ public actor OVSManager: OVSManaging {
             monitorRequests[table] = OVSDBMonitorRequest()
         }
         
-        return try await connection.startMonitoring(database: database, tables: monitorRequests)
+        return try await connection.startMonitoring(database: database, tables: monitorRequests).monitorId
     }
     
     public func stopMonitoring(monitorId: String) async throws {

--- a/Sources/SwiftOVN/Models/JSONRPCNotification.swift
+++ b/Sources/SwiftOVN/Models/JSONRPCNotification.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// A JSON-RPC notification received from the server (a message carrying a
+/// `method` with a null or absent `id`, so no response is expected).
+///
+/// OVSDB servers use notifications for monitor updates (`update`, `update2`)
+/// and lock state changes (`locked`, `stolen`).
+public struct JSONRPCNotification: Sendable {
+    public let method: String
+    public let params: JSONValue?
+
+    public init(method: String, params: JSONValue? = nil) {
+        self.method = method
+        self.params = params
+    }
+}

--- a/Sources/SwiftOVN/Models/OVSDBUpdate.swift
+++ b/Sources/SwiftOVN/Models/OVSDBUpdate.swift
@@ -1,10 +1,22 @@
 import Foundation
 
+/// A single row change from an OVSDB monitor.
+///
+/// Per RFC 7047 §4.1.6, `old`/`new` describe the kind of change:
+/// - insert (or initial row): `old` is nil, `new` has the row
+/// - delete: `old` has the row, `new` is nil
+/// - modify: `old` has the prior values of changed columns, `new` the row
 public struct OVSDBUpdate: Codable, Sendable {
+    /// The table the row belongs to.
+    public let table: String
+    /// The UUID of the changed row.
+    public let uuid: String
     public let old: OVSDBRow?
     public let new: OVSDBRow?
-    
-    public init(old: OVSDBRow? = nil, new: OVSDBRow? = nil) {
+
+    public init(table: String, uuid: String, old: OVSDBRow? = nil, new: OVSDBRow? = nil) {
+        self.table = table
+        self.uuid = uuid
         self.old = old
         self.new = new
     }

--- a/Tests/SwiftOVNTests/MessageRoutingTests.swift
+++ b/Tests/SwiftOVNTests/MessageRoutingTests.swift
@@ -1,0 +1,274 @@
+import XCTest
+import NIO
+import Logging
+@testable import SwiftOVN
+
+/// Tests for the inbound JSON-RPC message routing: notifications (null/absent
+/// id) reach subscribers, server `echo` requests are answered, responses are
+/// matched to pending requests, and connection loss fails everything cleanly.
+final class MessageRoutingTests: XCTestCase {
+
+    private func makeChannel() -> (channel: EmbeddedChannel, hub: JSONRPCNotificationHub, router: JSONRPCResponseRouter) {
+        let hub = JSONRPCNotificationHub()
+        let loop = EmbeddedEventLoop()
+        let router = JSONRPCResponseRouter(
+            logger: Logger(label: "test"),
+            eventLoopGroup: loop,
+            notificationHub: hub
+        )
+        let channel = EmbeddedChannel(handler: router, loop: loop)
+        return (channel, hub, router)
+    }
+
+    // MARK: - Notifications
+
+    func testUpdateNotificationWithNullIdIsDispatched() async throws {
+        let (channel, hub, _) = makeChannel()
+        defer { _ = try? channel.finish() }
+
+        let stream = hub.subscribe()
+
+        // Real ovsdb-server update notifications carry "id": null.
+        try channel.writeInbound(#"{"method":"update","params":["mon1",{"Logical_Switch":{"aa-bb":{"new":{"name":"ls0"}}}}],"id":null}"#)
+
+        var iterator = stream.makeAsyncIterator()
+        let notification = await iterator.next()
+
+        XCTAssertEqual(notification?.method, "update")
+        guard let notification,
+              case .array(let params)? = notification.params,
+              params.count == 2,
+              case .string(let monitorId) = params[0] else {
+            XCTFail("Expected array params with monitor ID first")
+            return
+        }
+        XCTAssertEqual(monitorId, "mon1")
+    }
+
+    func testNotificationWithoutIdKeyIsDispatched() async throws {
+        let (channel, hub, _) = makeChannel()
+        defer { _ = try? channel.finish() }
+
+        let stream = hub.subscribe()
+
+        try channel.writeInbound(#"{"method":"update","params":["mon2",{}]}"#)
+
+        var iterator = stream.makeAsyncIterator()
+        let notification = await iterator.next()
+        XCTAssertEqual(notification?.method, "update")
+    }
+
+    func testNotificationsAreBufferedBetweenReads() async throws {
+        let (channel, hub, _) = makeChannel()
+        defer { _ = try? channel.finish() }
+
+        let stream = hub.subscribe()
+
+        // Deliver several notifications before the consumer starts iterating;
+        // none may be dropped.
+        for index in 1...3 {
+            try channel.writeInbound(#"{"method":"update","params":["mon\#(index)",{}],"id":null}"#)
+        }
+
+        var received: [String] = []
+        var iterator = stream.makeAsyncIterator()
+        for _ in 1...3 {
+            guard let notification = await iterator.next(),
+                  case .array(let params)? = notification.params,
+                  case .string(let monitorId) = params[0] else {
+                XCTFail("Missing buffered notification")
+                return
+            }
+            received.append(monitorId)
+        }
+        XCTAssertEqual(received, ["mon1", "mon2", "mon3"])
+    }
+
+    func testEverySubscriberReceivesEachNotification() async throws {
+        let (channel, hub, _) = makeChannel()
+        defer { _ = try? channel.finish() }
+
+        let first = hub.subscribe()
+        let second = hub.subscribe()
+
+        try channel.writeInbound(#"{"method":"update","params":["mon1",{}],"id":null}"#)
+
+        var firstIterator = first.makeAsyncIterator()
+        var secondIterator = second.makeAsyncIterator()
+        let fromFirst = await firstIterator.next()
+        let fromSecond = await secondIterator.next()
+        XCTAssertEqual(fromFirst?.method, "update")
+        XCTAssertEqual(fromSecond?.method, "update")
+    }
+
+    // MARK: - Server echo requests
+
+    func testServerEchoRequestGetsReply() throws {
+        let (channel, _, _) = makeChannel()
+        defer { _ = try? channel.finish() }
+
+        try channel.writeInbound(#"{"method":"echo","params":["ping"],"id":42}"#)
+
+        guard let reply = try channel.readOutbound(as: String.self) else {
+            XCTFail("Expected an echo reply to be written")
+            return
+        }
+
+        let replyObject = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(reply.utf8)) as? [String: Any]
+        )
+        XCTAssertEqual(replyObject["id"] as? Int, 42)
+        XCTAssertEqual(replyObject["result"] as? [String], ["ping"])
+        XCTAssertTrue(replyObject["error"] is NSNull)
+    }
+
+    func testServerEchoReplyPreservesStringId() throws {
+        let (channel, _, _) = makeChannel()
+        defer { _ = try? channel.finish() }
+
+        try channel.writeInbound(#"{"method":"echo","params":[],"id":"echo-7"}"#)
+
+        guard let reply = try channel.readOutbound(as: String.self) else {
+            XCTFail("Expected an echo reply to be written")
+            return
+        }
+
+        let replyObject = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(reply.utf8)) as? [String: Any]
+        )
+        XCTAssertEqual(replyObject["id"] as? String, "echo-7")
+        XCTAssertEqual((replyObject["result"] as? [Any])?.count, 0)
+    }
+
+    func testUnknownServerRequestProducesNoReply() throws {
+        let (channel, _, _) = makeChannel()
+        defer { _ = try? channel.finish() }
+
+        try channel.writeInbound(#"{"method":"frobnicate","params":[],"id":9}"#)
+
+        XCTAssertNil(try channel.readOutbound(as: String.self))
+    }
+
+    // MARK: - Responses
+
+    func testResponseIsRoutedToPendingRequest() throws {
+        let (channel, _, router) = makeChannel()
+        defer { _ = try? channel.finish() }
+
+        let future = router.waitForResponse(
+            requestId: .number(7),
+            type: JSONRPCResponse<[String]>.self,
+            timeout: .seconds(30)
+        )
+
+        try channel.writeInbound(#"{"id":7,"result":["OVN_Northbound"],"error":null}"#)
+
+        let response = try future.wait()
+        XCTAssertEqual(response.result, ["OVN_Northbound"])
+        XCTAssertNil(response.error)
+    }
+
+    func testTimedOutRequestIsRemovedAndLateResponseIsIgnored() throws {
+        let (channel, _, router) = makeChannel()
+        defer { _ = try? channel.finish() }
+
+        let future = router.waitForResponse(
+            requestId: .number(1),
+            type: JSONRPCResponse<JSONValue>.self,
+            timeout: .seconds(5)
+        )
+
+        channel.embeddedEventLoop.advanceTime(by: .seconds(5))
+
+        XCTAssertThrowsError(try future.wait()) { error in
+            guard case OVNManagerError.timeoutError = error else {
+                XCTFail("Expected timeoutError, got \(error)")
+                return
+            }
+        }
+
+        // A response arriving after the timeout must be ignored gracefully,
+        // not fulfill the already-failed promise (which would crash).
+        XCTAssertNoThrow(try channel.writeInbound(#"{"id":1,"result":{},"error":null}"#))
+    }
+
+    // MARK: - Connection loss
+
+    func testChannelInactiveFailsPendingRequests() throws {
+        let (channel, _, router) = makeChannel()
+        defer { _ = try? channel.finish() }
+
+        let future = router.waitForResponse(
+            requestId: .number(3),
+            type: JSONRPCResponse<JSONValue>.self,
+            timeout: .seconds(30)
+        )
+
+        channel.pipeline.fireChannelInactive()
+
+        XCTAssertThrowsError(try future.wait()) { error in
+            guard case OVNManagerError.connectionFailed = error else {
+                XCTFail("Expected connectionFailed, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testChannelInactiveFinishesNotificationStreams() async throws {
+        let (channel, hub, _) = makeChannel()
+        defer { _ = try? channel.finish() }
+
+        let stream = hub.subscribe()
+
+        channel.pipeline.fireChannelInactive()
+
+        var iterator = stream.makeAsyncIterator()
+        let value = await iterator.next()
+        XCTAssertNil(value, "Stream should finish when the connection closes")
+    }
+}
+
+// MARK: - Table Updates Parsing
+
+final class OVSDBTableUpdatesParsingTests: XCTestCase {
+
+    private func tableUpdates(_ json: String) throws -> [OVSDBUpdate] {
+        let value = try JSONDecoder().decode(JSONValue.self, from: Data(json.utf8))
+        return OVSDBConnection.parseTableUpdates(value)
+    }
+
+    func testParsingCarriesTableUUIDOldAndNew() throws {
+        let updates = try tableUpdates(#"""
+        {
+          "Logical_Switch": {
+            "uuid-insert": {"new": {"name": "ls0"}},
+            "uuid-delete": {"old": {"name": "ls1"}}
+          },
+          "Logical_Switch_Port": {
+            "uuid-modify": {"old": {"name": "p0"}, "new": {"name": "p1"}}
+          }
+        }
+        """#)
+
+        XCTAssertEqual(updates.count, 3)
+
+        let insert = try XCTUnwrap(updates.first { $0.uuid == "uuid-insert" })
+        XCTAssertEqual(insert.table, "Logical_Switch")
+        XCTAssertNil(insert.old)
+        XCTAssertEqual(insert.new?["name"], .string("ls0"))
+
+        let delete = try XCTUnwrap(updates.first { $0.uuid == "uuid-delete" })
+        XCTAssertEqual(delete.table, "Logical_Switch")
+        XCTAssertEqual(delete.old?["name"], .string("ls1"))
+        XCTAssertNil(delete.new)
+
+        let modify = try XCTUnwrap(updates.first { $0.uuid == "uuid-modify" })
+        XCTAssertEqual(modify.table, "Logical_Switch_Port")
+        XCTAssertEqual(modify.old?["name"], .string("p0"))
+        XCTAssertEqual(modify.new?["name"], .string("p1"))
+    }
+
+    func testParsingNonObjectValueReturnsEmpty() throws {
+        XCTAssertTrue(try tableUpdates(#"[1,2,3]"#).isEmpty)
+    }
+}


### PR DESCRIPTION
## Problem

The monitoring path was non-functional and long-lived connections were dropped. A code review confirmed:

1. **Updates never yielded** — `monitorUpdates()` looked for `method`/`params` inside `response.result`, but real `update` notifications carry them at the top level; the router also discarded any message whose `id` is JSON `null` (how notifications are marked) as an "invalid ID type".
2. **Server `echo` requests never answered** — RFC 7047 §4.1.11 requires a reply; with an inactivity probe configured, ovsdb-server closes the connection.
3. **Monitor stream self-destructed after 60s idle** — `receiveAny(timeout: 60s)` finished the stream on timeout, and notifications arriving between `receiveAny` registrations were dropped.
4. **Crash risk** — a timed-out `waitForAnyResponse` promise stayed in `anyResponseWaiters`; the next notification fulfilled the already-failed `EventLoopPromise` → precondition failure.
5. **Connection loss left in-flight requests hanging** — no `channelInactive` handling, so a server restart stalled every in-flight call until its 30s timeout.
6. Minor: `monitor_cancel` sent as a notification instead of a request; the initial monitor reply discarded; `OVSDBUpdate` dropped the table name and row uuid.

## Redesign

`JSONRPCResponseRouter` now classifies every inbound message:

- **Response** (`id`, no `method`) → completes the matching pending request.
- **Notification** (`method`, null/absent `id`) → published to a `JSONRPCNotificationHub` that fans out to any number of subscribers via buffered `AsyncStream`s. Subscriptions can be created before `connect()` and before sending `monitor`, and buffering means nothing is dropped between iterations. Streams have **no idle timeout** — they live until the connection closes or the consumer cancels.
- **Server-to-client request** (`method` + real `id`) → `echo` is answered inline with the request params as the result, per RFC 7047 §4.1.11.

`channelInactive` fails all pending requests with `connectionFailed` and finishes notification streams, so a server restart is surfaced immediately instead of via 30s timeouts. Request timeouts now remove the pending entry before failing, so a late response is ignored instead of crashing. The old `receiveAny`/`waitForAnyResponse` machinery is removed.

Also:
- `monitor_cancel` is now a proper request awaiting the server's reply.
- `OVSDBConnection.startMonitoring` returns `(monitorId, initialUpdates)` — the initial rows from the monitor reply are parsed instead of discarded (managers keep their `-> String` protocol signature).
- `OVSDBUpdate` now carries `table` and `uuid` alongside `old`/`new`, and `OVSDBConnection.monitorUpdates(monitorId:)` can filter to one monitor.

## Tests

New `MessageRoutingTests` drive the router through an `EmbeddedChannel` (same pattern as the existing frame-decoder tests): null-id/absent-id notification dispatch, buffering across reads, multi-subscriber fan-out, echo replies (numeric and string ids), unknown server request ignored, response routing, timeout cleanup + late-response regression, and `channelInactive` behavior. `OVSDBTableUpdatesParsingTests` cover table/uuid/old/new extraction.

`swift test`: 38 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)