### PR TITLE
Fix integer 0/1 serialized as boolean, breaking OVSDB inserts

### DIFF
--- a/Sources/SwiftOVN/Core/JSONRPCClient.swift
+++ b/Sources/SwiftOVN/Core/JSONRPCClient.swift
@@ -202,13 +202,32 @@ public actor JSONRPCClient {
 
 // MARK: - Helper Functions
 
-private func convertToJSONValue(_ object: Any) throws -> JSONValue {
+/// A JSON boolean and an integer 0/1 both bridge to `NSNumber` once a value
+/// has been through `JSONSerialization`. On Linux Foundation
+/// `(0 as NSNumber) as? Bool` succeeds and returns `false` (likewise `1` →
+/// `true`), so this distinguishes a genuine boolean by its underlying
+/// CoreFoundation / Objective-C type rather than trusting an `as? Bool` cast.
+func isBooleanNSNumber(_ number: NSNumber) -> Bool {
+    #if canImport(ObjectiveC)
+    return CFGetTypeID(number) == CFBooleanGetTypeID()
+    #else
+    return String(cString: number.objCType) == "c"
+    #endif
+}
+
+func convertToJSONValue(_ object: Any) throws -> JSONValue {
     if object is NSNull {
         return .null
+    } else if let number = object as? NSNumber {
+        // Must precede the `as? Bool` branch: an integer NSNumber holding 0 or
+        // 1 also casts to Bool on Linux, so checking Bool first turned integer
+        // 0/1 into false/true. That silently serialized an OVSDB `wait` op's
+        // `timeout: 0` as `"timeout": false`, which ovsdb-server rejects
+        // ("Type mismatch for member 'timeout'"), breaking every insert that
+        // attaches a row to a parent (logical switch ports, bridges, ...).
+        return isBooleanNSNumber(number) ? .boolean(number.boolValue) : .number(number.doubleValue)
     } else if let bool = object as? Bool {
         return .boolean(bool)
-    } else if let number = object as? NSNumber {
-        return .number(number.doubleValue)
     } else if let string = object as? String {
         return .string(string)
     } else if let array = object as? [Any] {

--- a/Sources/SwiftOVN/Models/OVNManagerError.swift
+++ b/Sources/SwiftOVN/Models/OVNManagerError.swift
@@ -10,3 +10,31 @@ public enum OVNManagerError: Error, Sendable {
     case invalidSocket(String)
     case operationFailed(String)
 }
+
+// Without an explicit `errorDescription`, bridging to `NSError` discards the
+// associated messages: `localizedDescription` becomes the useless
+// "The operation could not be completed. (SwiftOVN.OVNManagerError error 6.)".
+// That hid the real ovsdb rejection (e.g. `operationFailed`'s transaction
+// message) behind an opaque case index. Surface the payload instead.
+extension OVNManagerError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .connectionFailed(let message):
+            return "OVN connection failed: \(message)"
+        case .invalidResponse(let message):
+            return "Invalid OVSDB response: \(message)"
+        case .timeoutError:
+            return "OVSDB operation timed out"
+        case .encodingError(let error):
+            return "OVSDB request encoding failed: \(error)"
+        case .decodingError(let error):
+            return "OVSDB response decoding failed: \(error)"
+        case .rpcError(let error):
+            return "OVSDB JSON-RPC error: \(error)"
+        case .invalidSocket(let path):
+            return "Invalid OVSDB socket: \(path)"
+        case .operationFailed(let message):
+            return message
+        }
+    }
+}

--- a/Tests/SwiftOVNTests/JSONValueConversionTests.swift
+++ b/Tests/SwiftOVNTests/JSONValueConversionTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import XCTest
+@testable import SwiftOVN
+
+/// Regression tests for `convertToJSONValue`, the bridge from
+/// `JSONSerialization` output back into the `JSONValue` wire tree.
+///
+/// The bug: an integer `NSNumber` holding 0 or 1 also casts to `Bool` on Linux
+/// Foundation, so checking `as? Bool` before `as? NSNumber` turned integer 0/1
+/// into `false`/`true`. An OVSDB `wait` op's `timeout: 0` therefore went out as
+/// `"timeout": false`, which ovsdb-server rejects ("Type mismatch for member
+/// 'timeout'"), breaking every `insertAttached`-based operation (logical switch
+/// ports, bridges).
+final class JSONValueConversionTests: XCTestCase {
+
+    /// Round-trips a value through the exact path `JSONRPCClient.transact` uses:
+    /// `JSONEncoder` → `JSONSerialization.jsonObject` → `convertToJSONValue`.
+    private func roundTrip<T: Encodable>(_ value: T) throws -> JSONValue {
+        let data = try JSONEncoder().encode(value)
+        let object = try JSONSerialization.jsonObject(with: data)
+        return try convertToJSONValue(object)
+    }
+
+    private struct Sample: Encodable {
+        let zero: Int
+        let one: Int
+        let big: Int
+        let flagTrue: Bool
+        let flagFalse: Bool
+    }
+
+    func testIntegersZeroAndOneStayNumbers() throws {
+        let json = try roundTrip(Sample(zero: 0, one: 1, big: 42, flagTrue: true, flagFalse: false))
+        guard case .object(let object) = json else {
+            return XCTFail("expected object, got \(json)")
+        }
+        XCTAssertEqual(object["zero"], .number(0), "integer 0 must not become boolean false")
+        XCTAssertEqual(object["one"], .number(1), "integer 1 must not become boolean true")
+        XCTAssertEqual(object["big"], .number(42))
+        XCTAssertEqual(object["flagTrue"], .boolean(true))
+        XCTAssertEqual(object["flagFalse"], .boolean(false))
+    }
+
+    /// The headline regression: a `wait` op with `timeout: 0` must serialize
+    /// `timeout` as the integer `0`, not the boolean `false`.
+    func testWaitOperationTimeoutSerializesAsInteger() throws {
+        let waitOp = OVSDBOperation(
+            op: "wait",
+            table: "Logical_Switch",
+            whereConditions: [OVSDBCondition(column: "name", function: "==", value: .string("default"))],
+            columns: ["name"],
+            rows: [["name": .string("default")]],
+            until: "==",
+            timeout: 0
+        )
+        let json = try roundTrip(waitOp)
+        guard case .object(let object) = json else {
+            return XCTFail("expected object, got \(json)")
+        }
+        XCTAssertEqual(object["timeout"], .number(0), "wait op timeout must be integer 0, not boolean false")
+        XCTAssertEqual(object["until"], .string("=="))
+        XCTAssertEqual(object["op"], .string("wait"))
+    }
+}


### PR DESCRIPTION
## Summary

`JSONRPCClient.convertToJSONValue` checked `as? Bool` **before** `as? NSNumber`. Once a value has been through `JSONSerialization`, a JSON boolean and an integer `0`/`1` both bridge to `NSNumber`, and on Linux Foundation `(0 as NSNumber) as? Bool` succeeds and returns `false` (likewise `1` → `true`). So integer `0`/`1` serialized as `false`/`true`.

The concrete failure: the `wait` operation that `insertAttached` prepends (with `timeout: 0`) went out as `"timeout": false`, which ovsdb-server rejects:

```
syntax error: Type mismatch for member 'timeout'
```

Because **every** attach-to-parent insert uses that `wait` op, all logical-switch-port and bridge creation failed — i.e. OVN VM networking was fully broken. Interestingly a plain `ovn-nbctl lsp-add` succeeds, because it doesn't emit that `wait` op, which made this look like a downstream problem at first.

## Fix

- Inspect `NSNumber` **before** `Bool` and only treat a genuine CoreFoundation / objc boolean as `.boolean` (the same distinction `OVSDBRowEncoder.isBoolean` already makes), otherwise `.number`.
- Conform `OVNManagerError` to `LocalizedError`. Without it, bridging to `NSError` discarded the associated messages, so `localizedDescription` was the opaque `The operation could not be completed. (SwiftOVN.OVNManagerError error 6.)` — which is exactly what hid the real ovsdb rejection during diagnosis. (Aside: `error 6` is `operationFailed`, not `invalidSocket` — Swift numbers payload-carrying cases first.)

## Tests

Adds `JSONValueConversionTests` round-tripping values through the real `JSONEncoder` → `JSONSerialization` → `convertToJSONValue` path:
- integer `0`/`1` stay `.number`, real booleans stay `.boolean`
- a full `wait` `OVSDBOperation` asserts `timeout` serializes as integer `0`

Full suite: 66 tests, 0 failures.

## Validation

Verified end-to-end against strato on a Linux/OVN host: with this fix the agent creates the logical switch port + TAP, QEMU boots with `-netdev tap,...` (TAP enslaved to `ovs-system`), and the VM reaches `Running`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)