### PR TITLE
Add TCP/SSL transport for OVSDB connections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ The codebase follows a clean architecture with clear separation of concerns:
 
 1. **Low-level networking** (`/Sources/SwiftOVN/Core/`):
    - `JSONRPCClient.swift`: Handles JSON-RPC protocol communication
-   - `UnixSocketConnection.swift`: SwiftNIO-based Unix socket implementation
+   - `OVSDBSocketConnection.swift`: SwiftNIO-based transport over Unix socket, TCP, or TLS (`OVSDBEndpoint` selects the transport; `UnixSocketConnection` remains as a typealias)
    - `OVSDBConnection.swift`: OVSDB protocol with real-time monitoring via AsyncSequence
 
 2. **High-level managers** (`/Sources/SwiftOVN/Managers/`):

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "058439bcf344c789c39cb2cf02843c7e3b1cdd7420c26d290f23d9a3d753dc47",
   "pins" : [
     {
       "identity" : "swift-atomics",
@@ -37,6 +38,15 @@
       }
     },
     {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
+        "version" : "2.37.0"
+      }
+    },
+    {
       "identity" : "swift-system",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
@@ -46,5 +56,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "058439bcf344c789c39cb2cf02843c7e3b1cdd7420c26d290f23d9a3d753dc47",
+  "originHash" : "7cdbaf34bc3a9c3472791725b8ba82fe34639667e0aaf5201ef7789939589244",
   "pins" : [
     {
       "identity" : "swift-atomics",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
-        "version" : "2.37.0"
+        "revision" : "df9c3406028e3297246e6e7081977a167318b692",
+        "version" : "2.36.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.26.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],
     targets: [
@@ -28,6 +29,7 @@ let package = Package(
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
+                .product(name: "NIOSSL", package: "swift-nio-ssl"),
                 .product(name: "Logging", package: "swift-log"),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,9 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.26.0"),
+        // 2.37.0 requires Swift tools 6.1; stay below it while this package
+        // and CI build with Swift 6.0.
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", "2.26.0"..<"2.37.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -31,6 +31,7 @@ let package = Package(
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
+                .product(name: "NIOTLS", package: "swift-nio"),
                 .product(name: "NIOSSL", package: "swift-nio-ssl"),
                 .product(name: "Logging", package: "swift-log"),
             ]
@@ -42,7 +43,10 @@ let package = Package(
         ),
         .testTarget(
             name: "SwiftOVNTests",
-            dependencies: ["SwiftOVN"]
+            dependencies: [
+                "SwiftOVN",
+                .product(name: "NIOSSL", package: "swift-nio-ssl"),
+            ]
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # SwiftOVN
 
-A comprehensive Swift package for managing OVN (Open Virtual Network) and OVS (Open vSwitch) through their JSON-RPC APIs over Unix domain sockets.
+A comprehensive Swift package for managing OVN (Open Virtual Network) and OVS (Open vSwitch) through their JSON-RPC APIs over Unix domain sockets, TCP, or TLS.
 
 ## Features
 
 - 🚀 **Type-Safe Swift Models**: Strongly typed, Codable structs for all OVN and OVS database schemas
-- ⚡ **High Performance**: SwiftNIO-based asynchronous Unix socket communication
+- ⚡ **High Performance**: SwiftNIO-based asynchronous socket communication
+- 🔌 **Flexible Transport**: Local Unix sockets or remote databases over `tcp:`/`ssl:` (NIOSSL)
 - 🔄 **Modern Concurrency**: Built with Swift's async/await and AsyncSequence
 - 📡 **Real-time Monitoring**: Monitor database changes in real-time using AsyncSequence
 - 🌍 **Cross-Platform**: Works on Linux, macOS, and other platforms supported by Swift
@@ -106,8 +107,9 @@ try await SwiftOVN.stopMonitoring(monitorId: monitorId)
 
 ### Core Components
 
-- **JSONRPCClient**: Low-level JSON-RPC communication over Unix sockets
-- **UnixSocketConnection**: SwiftNIO-based Unix domain socket handling
+- **JSONRPCClient**: Low-level JSON-RPC communication over any OVSDB transport
+- **OVSDBSocketConnection**: SwiftNIO-based Unix socket, TCP, and TLS transport (`UnixSocketConnection` remains as an alias)
+- **OVSDBEndpoint**: Endpoint description (`.unix`/`.tcp`/`.ssl`) with OVN-style string parsing
 - **OVSDBConnection**: OVSDB protocol implementation with monitoring support
 - **SwiftOVN**: High-level interface for OVN operations
 - **OVSManager**: High-level interface for OVS operations
@@ -136,6 +138,34 @@ The package includes comprehensive Swift models for:
 - `OVSQoS` - Quality of service policies
 
 ## Advanced Usage
+
+### Remote Databases (TCP/SSL)
+
+A central OVN deployment usually exposes its northbound database on port 6641
+and southbound on 6642. Connect to a remote database with an `OVSDBEndpoint`:
+
+```swift
+// Cleartext TCP
+let manager = OVNManager(endpoint: .tcp(host: "ovn-central.example.com", port: 6641))
+try await manager.connect()
+
+// TLS with an ovn-pki-style private CA and client certificate
+let tls = OVSDBTLSConfiguration(
+    caCertificatePath: "/etc/ovn/cacert.pem",
+    clientCertificatePath: "/etc/ovn/client-cert.pem",
+    clientPrivateKeyPath: "/etc/ovn/client-privkey.pem"
+)
+let secureManager = OVNManager(
+    endpoint: .ssl(host: "ovn-central.example.com", port: 6641, tls: tls),
+    database: OVNDatabase.northbound
+)
+
+// OVN-style connection strings are also supported
+let endpoint = try OVSDBEndpoint(parsing: "tcp:ovn-central.example.com:6641")
+```
+
+The existing `socketPath:` initializers are unchanged and equivalent to
+`.unix(path:)`.
 
 ### Custom Connection Configuration
 

--- a/Sources/SwiftOVN/Core/JSONRPCClient.swift
+++ b/Sources/SwiftOVN/Core/JSONRPCClient.swift
@@ -3,16 +3,26 @@ import NIO
 import Logging
 
 public actor JSONRPCClient {
-    private let connection: UnixSocketConnection
+    private let connection: any OVSDBTransport
     private let logger: Logger
     private var requestId: Int = 0
-    
-    public init(socketPath: String, eventLoopGroup: EventLoopGroup? = nil, logger: Logger? = nil) {
-        self.connection = UnixSocketConnection(
-            socketPath: socketPath, 
+
+    public init(endpoint: OVSDBEndpoint, eventLoopGroup: EventLoopGroup? = nil, logger: Logger? = nil) {
+        self.connection = OVSDBSocketConnection(
+            endpoint: endpoint,
             eventLoopGroup: eventLoopGroup,
             logger: logger
         )
+        self.logger = logger ?? Logger(label: "ovn-manager.jsonrpc-client")
+    }
+
+    public init(socketPath: String, eventLoopGroup: EventLoopGroup? = nil, logger: Logger? = nil) {
+        self.init(endpoint: .unix(path: socketPath), eventLoopGroup: eventLoopGroup, logger: logger)
+    }
+
+    /// Runs the client over a caller-supplied transport (e.g. a mock in tests).
+    public init(transport: any OVSDBTransport, logger: Logger? = nil) {
+        self.connection = transport
         self.logger = logger ?? Logger(label: "ovn-manager.jsonrpc-client")
     }
     

--- a/Sources/SwiftOVN/Core/OVSDBConnection.swift
+++ b/Sources/SwiftOVN/Core/OVSDBConnection.swift
@@ -7,13 +7,17 @@ public actor OVSDBConnection {
     private let logger: Logger
     private var activeMonitors: Set<String> = []
     
-    public init(socketPath: String, eventLoopGroup: EventLoopGroup? = nil, logger: Logger? = nil) {
+    public init(endpoint: OVSDBEndpoint, eventLoopGroup: EventLoopGroup? = nil, logger: Logger? = nil) {
         self.client = JSONRPCClient(
-            socketPath: socketPath,
+            endpoint: endpoint,
             eventLoopGroup: eventLoopGroup,
             logger: logger
         )
         self.logger = logger ?? Logger(label: "ovn-manager.ovsdb-connection")
+    }
+
+    public init(socketPath: String, eventLoopGroup: EventLoopGroup? = nil, logger: Logger? = nil) {
+        self.init(endpoint: .unix(path: socketPath), eventLoopGroup: eventLoopGroup, logger: logger)
     }
     
     public func connect() async throws {

--- a/Sources/SwiftOVN/Core/OVSDBEndpoint.swift
+++ b/Sources/SwiftOVN/Core/OVSDBEndpoint.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+/// Where an OVSDB server is listening.
+///
+/// OVSDB servers accept connections over a local Unix domain socket or over
+/// TCP, optionally protected by TLS (`ssl:` in OVN/OVS tooling). A remote
+/// endpoint is what allows several hypervisors to share one central
+/// northbound/southbound database.
+public enum OVSDBEndpoint: Sendable, Equatable {
+    /// A local Unix domain socket, e.g. `/var/run/ovn/ovnnb_db.sock`.
+    case unix(path: String)
+    /// A cleartext TCP connection, e.g. `tcp:central.example.com:6641`.
+    case tcp(host: String, port: Int)
+    /// A TLS-protected TCP connection, e.g. `ssl:central.example.com:6641`.
+    case ssl(host: String, port: Int, tls: OVSDBTLSConfiguration)
+
+    /// Default OVN northbound database port.
+    public static let defaultNorthboundPort = 6641
+    /// Default OVN southbound database port.
+    public static let defaultSouthboundPort = 6642
+
+    /// A TLS endpoint using the default TLS configuration (system trust
+    /// roots, server certificate verification on, no client certificate).
+    public static func ssl(host: String, port: Int) -> OVSDBEndpoint {
+        return .ssl(host: host, port: port, tls: OVSDBTLSConfiguration())
+    }
+
+    /// Parses an OVN/OVS-style connection string:
+    ///
+    /// - `unix:/var/run/ovn/ovnnb_db.sock`
+    /// - `tcp:192.0.2.1:6641` or `tcp:[2001:db8::1]:6641`
+    /// - `ssl:central.example.com:6642`
+    ///
+    /// TLS options (CA, client certificate) cannot be expressed in the string
+    /// form; parse the endpoint and re-create it with `.ssl(host:port:tls:)`
+    /// when they are needed.
+    public init(parsing string: String) throws {
+        guard let colonIndex = string.firstIndex(of: ":") else {
+            throw OVNManagerError.connectionFailed("Invalid OVSDB endpoint '\(string)': expected unix:, tcp: or ssl: prefix")
+        }
+
+        let scheme = String(string[..<colonIndex])
+        let remainder = String(string[string.index(after: colonIndex)...])
+
+        switch scheme {
+        case "unix":
+            guard !remainder.isEmpty else {
+                throw OVNManagerError.connectionFailed("Invalid OVSDB endpoint '\(string)': missing socket path")
+            }
+            self = .unix(path: remainder)
+        case "tcp", "ssl":
+            let (host, port) = try Self.parseHostPort(remainder, in: string)
+            if scheme == "tcp" {
+                self = .tcp(host: host, port: port)
+            } else {
+                self = .ssl(host: host, port: port, tls: OVSDBTLSConfiguration())
+            }
+        default:
+            throw OVNManagerError.connectionFailed("Invalid OVSDB endpoint '\(string)': unsupported scheme '\(scheme)'")
+        }
+    }
+
+    private static func parseHostPort(_ remainder: String, in original: String) throws -> (host: String, port: Int) {
+        let host: String
+        let portString: String
+
+        if remainder.hasPrefix("[") {
+            // Bracketed IPv6 literal: [2001:db8::1]:6641
+            guard let closingBracket = remainder.firstIndex(of: "]") else {
+                throw OVNManagerError.connectionFailed("Invalid OVSDB endpoint '\(original)': unterminated IPv6 address")
+            }
+            host = String(remainder[remainder.index(after: remainder.startIndex)..<closingBracket])
+            let afterBracket = remainder[remainder.index(after: closingBracket)...]
+            guard afterBracket.hasPrefix(":") else {
+                throw OVNManagerError.connectionFailed("Invalid OVSDB endpoint '\(original)': missing port")
+            }
+            portString = String(afterBracket.dropFirst())
+        } else {
+            guard let portColon = remainder.lastIndex(of: ":") else {
+                throw OVNManagerError.connectionFailed("Invalid OVSDB endpoint '\(original)': missing port")
+            }
+            host = String(remainder[..<portColon])
+            portString = String(remainder[remainder.index(after: portColon)...])
+        }
+
+        guard !host.isEmpty else {
+            throw OVNManagerError.connectionFailed("Invalid OVSDB endpoint '\(original)': missing host")
+        }
+        guard let port = Int(portString), (1...65535).contains(port) else {
+            throw OVNManagerError.connectionFailed("Invalid OVSDB endpoint '\(original)': invalid port '\(portString)'")
+        }
+        return (host, port)
+    }
+}
+
+extension OVSDBEndpoint: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .unix(let path):
+            return "unix:\(path)"
+        case .tcp(let host, let port):
+            return "tcp:\(Self.formatHost(host)):\(port)"
+        case .ssl(let host, let port, _):
+            return "ssl:\(Self.formatHost(host)):\(port)"
+        }
+    }
+
+    private static func formatHost(_ host: String) -> String {
+        // Bracket IPv6 literals so host and port remain unambiguous.
+        return host.contains(":") ? "[\(host)]" : host
+    }
+}
+
+/// TLS settings for an `ssl:` OVSDB endpoint.
+///
+/// OVN deployments typically run a private PKI (`ovn-pki`), so the CA that
+/// signed the server certificate must be supplied explicitly, and the server
+/// usually requires a client certificate signed by the same CA. All paths
+/// point to PEM files, matching the files `ovn-pki` produces.
+public struct OVSDBTLSConfiguration: Sendable, Equatable {
+    /// PEM file with the CA certificate(s) used to verify the server
+    /// (ovsdb-server's `--ca-cert`). When nil, the system trust roots are used.
+    public var caCertificatePath: String?
+    /// PEM file with the client certificate chain presented to the server
+    /// (the ovs/ovn `--certificate` counterpart).
+    public var clientCertificatePath: String?
+    /// PEM file with the private key for the client certificate
+    /// (the ovs/ovn `--private-key` counterpart).
+    public var clientPrivateKeyPath: String?
+    /// Whether the server certificate is verified against the trust roots.
+    /// Disable only for lab setups whose certificates are not verifiable.
+    public var verifiesServerCertificate: Bool
+    /// Hostname used for SNI and certificate hostname verification. Defaults
+    /// to the endpoint host; set explicitly when connecting by IP address to
+    /// a certificate issued for a DNS name.
+    public var serverHostname: String?
+
+    public init(
+        caCertificatePath: String? = nil,
+        clientCertificatePath: String? = nil,
+        clientPrivateKeyPath: String? = nil,
+        verifiesServerCertificate: Bool = true,
+        serverHostname: String? = nil
+    ) {
+        self.caCertificatePath = caCertificatePath
+        self.clientCertificatePath = clientCertificatePath
+        self.clientPrivateKeyPath = clientPrivateKeyPath
+        self.verifiesServerCertificate = verifiesServerCertificate
+        self.serverHostname = serverHostname
+    }
+}

--- a/Sources/SwiftOVN/Core/OVSDBSocketConnection.swift
+++ b/Sources/SwiftOVN/Core/OVSDBSocketConnection.swift
@@ -1,24 +1,31 @@
 import Foundation
 import NIO
 import NIOPosix
+import NIOSSL
 import Logging
 
-public final class UnixSocketConnection: @unchecked Sendable {
+/// Preserved name from when the connection was Unix-socket only.
+public typealias UnixSocketConnection = OVSDBSocketConnection
+
+public final class OVSDBSocketConnection: OVSDBTransport, @unchecked Sendable {
     private let eventLoopGroup: EventLoopGroup
     private let logger: Logger
     private var channel: Channel?
-    private let socketPath: String
+    private let endpoint: OVSDBEndpoint
     private var isConnected: Bool = false
     private var responseRouter: JSONRPCResponseRouter?
     private let connectionLock = NSLock()
     private let notificationHub = JSONRPCNotificationHub()
 
-    public init(socketPath: String, eventLoopGroup: EventLoopGroup? = nil, logger: Logger? = nil) {
-        self.socketPath = socketPath
+    public init(endpoint: OVSDBEndpoint, eventLoopGroup: EventLoopGroup? = nil, logger: Logger? = nil) {
+        self.endpoint = endpoint
         self.eventLoopGroup = eventLoopGroup ?? MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        self.logger = logger ?? Logger(label: "ovn-manager.unix-socket")
+        self.logger = logger ?? Logger(label: "ovn-manager.socket")
     }
 
+    public convenience init(socketPath: String, eventLoopGroup: EventLoopGroup? = nil, logger: Logger? = nil) {
+        self.init(endpoint: .unix(path: socketPath), eventLoopGroup: eventLoopGroup, logger: logger)
+    }
 
     public func connect() -> EventLoopFuture<Void> {
         connectionLock.lock()
@@ -26,20 +33,38 @@ public final class UnixSocketConnection: @unchecked Sendable {
         connectionLock.unlock()
 
         guard !alreadyConnected else {
-            logger.debug("Already connected to Unix socket")
+            logger.debug("Already connected to \(endpoint)")
             return eventLoopGroup.next().makeSucceededFuture(())
         }
 
-        logger.info("Connecting to Unix socket at: \(socketPath)")
-        logger.debug("Checking if socket file exists...")
+        logger.info("Connecting to OVSDB endpoint: \(endpoint)")
 
-        // Check if socket file exists
-        if !FileManager.default.fileExists(atPath: socketPath) {
-            logger.error("Socket file does not exist at path: \(socketPath)")
-            return eventLoopGroup.next().makeFailedFuture(OVNManagerError.connectionFailed("Socket file not found: \(socketPath)"))
+        // TLS state that must exist before the pipeline is built.
+        let sslContext: NIOSSLContext?
+        let sslServerHostname: String?
+        switch endpoint {
+        case .unix(let path):
+            if !FileManager.default.fileExists(atPath: path) {
+                logger.error("Socket file does not exist at path: \(path)")
+                return eventLoopGroup.next().makeFailedFuture(OVNManagerError.connectionFailed("Socket file not found: \(path)"))
+            }
+            sslContext = nil
+            sslServerHostname = nil
+        case .tcp:
+            sslContext = nil
+            sslServerHostname = nil
+        case .ssl(let host, _, let tls):
+            do {
+                sslContext = try Self.makeSSLContext(tls)
+            } catch {
+                logger.error("Failed to build TLS context: \(error)")
+                return eventLoopGroup.next().makeFailedFuture(OVNManagerError.connectionFailed("Invalid TLS configuration: \(error)"))
+            }
+            // SNI/hostname verification only applies to DNS names; NIOSSL
+            // rejects IP literals as SNI hostnames.
+            let hostname = tls.serverHostname ?? host
+            sslServerHostname = Self.isIPAddressLiteral(hostname) ? nil : hostname
         }
-
-        logger.debug("Socket file exists, creating bootstrap...")
 
         let bootstrap = ClientBootstrap(group: eventLoopGroup)
             .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
@@ -51,11 +76,22 @@ public final class UnixSocketConnection: @unchecked Sendable {
                     notificationHub: self.notificationHub
                 )
                 self.responseRouter = router
-                return channel.pipeline.addHandlers([
+
+                var handlers: [ChannelHandler] = []
+                if let sslContext {
+                    do {
+                        handlers.append(try NIOSSLClientHandler(context: sslContext, serverHostname: sslServerHostname))
+                    } catch {
+                        self.logger.error("Failed to create TLS handler: \(error)")
+                        return channel.eventLoop.makeFailedFuture(error)
+                    }
+                }
+                handlers.append(contentsOf: [
                     ByteToMessageHandler(OVSDBJSONFrameDecoder()),
                     MessageToByteHandler(StringToByteEncoder()),
                     router
-                ]).map { _ in
+                ] as [ChannelHandler])
+                return channel.pipeline.addHandlers(handlers).map { _ in
                     self.logger.debug("Channel pipeline initialized successfully")
                 }.flatMapError { error in
                     self.logger.error("Failed to initialize channel pipeline: \(error)")
@@ -63,26 +99,57 @@ public final class UnixSocketConnection: @unchecked Sendable {
                 }
             }
 
-        logger.debug("Attempting to connect to Unix domain socket...")
+        let connectFuture: EventLoopFuture<Channel>
+        switch endpoint {
+        case .unix(let path):
+            connectFuture = bootstrap.connect(unixDomainSocketPath: path)
+        case .tcp(let host, let port), .ssl(let host, let port, _):
+            connectFuture = bootstrap.connect(host: host, port: port)
+        }
 
-        return bootstrap.connect(unixDomainSocketPath: socketPath)
+        return connectFuture
             .map { channel in
                 self.logger.debug("Raw connection established, setting up channel...")
                 self.connectionLock.lock()
                 self.channel = channel
                 self.isConnected = true
                 self.connectionLock.unlock()
-                self.logger.info("Successfully connected to Unix socket")
+                self.logger.info("Successfully connected to \(self.endpoint)")
                 self.logger.debug("Channel active: \(channel.isActive), writable: \(channel.isWritable)")
             }
             .flatMapError { error in
-                self.logger.error("Failed to connect to Unix socket: \(error)")
+                self.logger.error("Failed to connect to \(self.endpoint): \(error)")
                 self.logger.error("Error type: \(type(of: error))")
                 if let ioError = error as? IOError {
                     self.logger.error("IO error code: \(ioError.errnoCode)")
                 }
-                return self.eventLoopGroup.next().makeFailedFuture(OVNManagerError.connectionFailed("Failed to connect to \(self.socketPath): \(error)"))
+                return self.eventLoopGroup.next().makeFailedFuture(OVNManagerError.connectionFailed("Failed to connect to \(self.endpoint): \(error)"))
             }
+    }
+
+    private static func makeSSLContext(_ tls: OVSDBTLSConfiguration) throws -> NIOSSLContext {
+        var configuration = TLSConfiguration.makeClientConfiguration()
+        if let caPath = tls.caCertificatePath {
+            configuration.trustRoots = .file(caPath)
+        }
+        if let certPath = tls.clientCertificatePath {
+            configuration.certificateChain = try NIOSSLCertificate.fromPEMFile(certPath).map { .certificate($0) }
+        }
+        if let keyPath = tls.clientPrivateKeyPath {
+            configuration.privateKey = .file(keyPath)
+        }
+        if !tls.verifiesServerCertificate {
+            configuration.certificateVerification = .none
+        }
+        return try NIOSSLContext(configuration: configuration)
+    }
+
+    private static func isIPAddressLiteral(_ host: String) -> Bool {
+        var ipv4 = in_addr()
+        var ipv6 = in6_addr()
+        return host.withCString { pointer in
+            inet_pton(AF_INET, pointer, &ipv4) == 1 || inet_pton(AF_INET6, pointer, &ipv6) == 1
+        }
     }
 
     public func disconnect() -> EventLoopFuture<Void> {
@@ -92,7 +159,7 @@ public final class UnixSocketConnection: @unchecked Sendable {
             return eventLoopGroup.next().makeSucceededFuture(())
         }
 
-        logger.info("Disconnecting from Unix socket")
+        logger.info("Disconnecting from \(endpoint)")
         self.isConnected = false
         self.responseRouter = nil
         connectionLock.unlock()
@@ -103,7 +170,7 @@ public final class UnixSocketConnection: @unchecked Sendable {
             self.connectionLock.lock()
             self.channel = nil
             self.connectionLock.unlock()
-            self.logger.info("Successfully disconnected from Unix socket")
+            self.logger.info("Successfully disconnected from \(self.endpoint)")
         }
     }
 
@@ -122,7 +189,7 @@ public final class UnixSocketConnection: @unchecked Sendable {
             let data = try encoder.encode(message)
             guard let jsonString = String(data: data, encoding: .utf8) else {
                 throw OVNManagerError.encodingError(
-                    NSError(domain: "UnixSocketConnection", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to convert data to string"])
+                    NSError(domain: "OVSDBSocketConnection", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to convert data to string"])
                 )
             }
 

--- a/Sources/SwiftOVN/Core/OVSDBSocketConnection.swift
+++ b/Sources/SwiftOVN/Core/OVSDBSocketConnection.swift
@@ -60,8 +60,12 @@ public final class OVSDBSocketConnection: OVSDBTransport, @unchecked Sendable {
                 logger.error("Failed to build TLS context: \(error)")
                 return eventLoopGroup.next().makeFailedFuture(OVNManagerError.connectionFailed("Invalid TLS configuration: \(error)"))
             }
-            // SNI/hostname verification only applies to DNS names; NIOSSL
-            // rejects IP literals as SNI hostnames.
+            // NIOSSL rejects IP literals as SNI hostnames (RFC 6066), so pass
+            // nil for them. This does not weaken verification: under
+            // .fullVerification NIOSSL still validates identity with a nil
+            // hostname by matching the connection's remote address against
+            // the certificate's IP SANs (NIOSSLHandler.validateHostname →
+            // validIdentityForService), and fails the handshake on no match.
             let hostname = tls.serverHostname ?? host
             sslServerHostname = Self.isIPAddressLiteral(hostname) ? nil : hostname
         }

--- a/Sources/SwiftOVN/Core/OVSDBSocketConnection.swift
+++ b/Sources/SwiftOVN/Core/OVSDBSocketConnection.swift
@@ -2,6 +2,7 @@ import Foundation
 import NIO
 import NIOPosix
 import NIOSSL
+import NIOTLS
 import Logging
 
 /// Preserved name from when the connection was Unix-socket only.
@@ -89,6 +90,7 @@ public final class OVSDBSocketConnection: OVSDBTransport, @unchecked Sendable {
                         self.logger.error("Failed to create TLS handler: \(error)")
                         return channel.eventLoop.makeFailedFuture(error)
                     }
+                    handlers.append(TLSHandshakeWaitHandler())
                 }
                 handlers.append(contentsOf: [
                     ByteToMessageHandler(OVSDBJSONFrameDecoder()),
@@ -112,6 +114,20 @@ public final class OVSDBSocketConnection: OVSDBTransport, @unchecked Sendable {
         }
 
         return connectFuture
+            .flatMap { channel -> EventLoopFuture<Channel> in
+                // For ssl: endpoints the TCP connect completing is not enough;
+                // certificate verification happens during the TLS handshake,
+                // so hold the connect future until the handshake finishes and
+                // fail it if verification fails.
+                guard sslContext != nil else {
+                    return channel.eventLoop.makeSucceededFuture(channel)
+                }
+                return channel.pipeline.handler(type: TLSHandshakeWaitHandler.self)
+                    .flatMap { handler in
+                        handler.handshakeFuture ?? channel.eventLoop.makeSucceededFuture(())
+                    }
+                    .map { channel }
+            }
             .map { channel in
                 self.logger.debug("Raw connection established, setting up channel...")
                 self.connectionLock.lock()
@@ -235,6 +251,74 @@ public final class OVSDBSocketConnection: OVSDBTransport, @unchecked Sendable {
         connectionLock.lock()
         defer { connectionLock.unlock() }
         return isConnected && channel?.isActive == true
+    }
+}
+
+// MARK: - TLS Handshake Wait
+
+/// Surfaces TLS handshake completion as a future, so `connect()` on an `ssl:`
+/// endpoint succeeds only after certificate verification instead of at TCP
+/// establishment. All members are accessed on the channel's event loop.
+final class TLSHandshakeWaitHandler: ChannelInboundHandler, @unchecked Sendable {
+    typealias InboundIn = Any
+
+    private let timeout: TimeAmount
+    private var promise: EventLoopPromise<Void>?
+    private var timeoutTask: Scheduled<Void>?
+    private var isComplete = false
+
+    init(timeout: TimeAmount = .seconds(30)) {
+        self.timeout = timeout
+    }
+
+    /// nil only before the handler is added to a pipeline.
+    var handshakeFuture: EventLoopFuture<Void>? {
+        return promise?.futureResult
+    }
+
+    func handlerAdded(context: ChannelHandlerContext) {
+        promise = context.eventLoop.makePromise(of: Void.self)
+        // A server that accepts TCP but never answers the ClientHello (e.g. an
+        // ssl: endpoint pointed at a cleartext port) would otherwise hang the
+        // connect forever.
+        let channel = context.channel
+        timeoutTask = context.eventLoop.scheduleTask(in: timeout) {
+            self.complete(.failure(OVNManagerError.connectionFailed("TLS handshake timed out")))
+            channel.close(promise: nil)
+        }
+    }
+
+    func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
+        if let tlsEvent = event as? TLSUserEvent, case .handshakeCompleted = tlsEvent {
+            complete(.success(()))
+        }
+        context.fireUserInboundEventTriggered(event)
+    }
+
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        complete(.failure(error))
+        context.fireErrorCaught(error)
+    }
+
+    func channelInactive(context: ChannelHandlerContext) {
+        complete(.failure(OVNManagerError.connectionFailed("Connection closed during TLS handshake")))
+        context.fireChannelInactive()
+    }
+
+    func handlerRemoved(context: ChannelHandlerContext) {
+        complete(.failure(OVNManagerError.connectionFailed("Connection closed before TLS handshake completed")))
+    }
+
+    private func complete(_ result: Result<Void, Error>) {
+        guard !isComplete else { return }
+        isComplete = true
+        timeoutTask?.cancel()
+        switch result {
+        case .success:
+            promise?.succeed(())
+        case .failure(let error):
+            promise?.fail(error)
+        }
     }
 }
 

--- a/Sources/SwiftOVN/Core/OVSDBTransport.swift
+++ b/Sources/SwiftOVN/Core/OVSDBTransport.swift
@@ -1,0 +1,24 @@
+import Foundation
+import NIO
+
+/// A bidirectional JSON-RPC transport to an OVSDB server.
+///
+/// `OVSDBSocketConnection` implements this over Unix domain sockets, TCP and
+/// TLS; the protocol exists so `JSONRPCClient` can also run over a custom or
+/// mock transport.
+public protocol OVSDBTransport: Sendable {
+    func connect() -> EventLoopFuture<Void>
+    func disconnect() -> EventLoopFuture<Void>
+    func send<T: Codable>(_ message: T) -> EventLoopFuture<Void>
+    func receive<T: Codable>(as type: T.Type, requestId: JSONRPCIdentifier, timeout: TimeAmount) -> EventLoopFuture<T>
+    /// See `OVSDBSocketConnection.notifications()`: the returned stream must
+    /// buffer from creation time and finish when the connection closes.
+    func notifications() -> AsyncStream<JSONRPCNotification>
+    var isConnectionActive: Bool { get }
+}
+
+public extension OVSDBTransport {
+    func receive<T: Codable>(as type: T.Type, requestId: JSONRPCIdentifier) -> EventLoopFuture<T> {
+        return receive(as: type, requestId: requestId, timeout: .seconds(30))
+    }
+}

--- a/Sources/SwiftOVN/Managers/OVNManager.swift
+++ b/Sources/SwiftOVN/Managers/OVNManager.swift
@@ -7,14 +7,18 @@ public actor OVNManager: OVNManaging {
     private let logger: Logger
     private let database: String
     
-    public init(socketPath: String, database: String = OVNDatabase.northbound, eventLoopGroup: EventLoopGroup? = nil, logger: Logger? = nil) {
+    public init(endpoint: OVSDBEndpoint, database: String = OVNDatabase.northbound, eventLoopGroup: EventLoopGroup? = nil, logger: Logger? = nil) {
         self.connection = OVSDBConnection(
-            socketPath: socketPath,
+            endpoint: endpoint,
             eventLoopGroup: eventLoopGroup,
             logger: logger
         )
         self.database = database
         self.logger = logger ?? Logger(label: "ovn-manager.ovn")
+    }
+
+    public init(socketPath: String, database: String = OVNDatabase.northbound, eventLoopGroup: EventLoopGroup? = nil, logger: Logger? = nil) {
+        self.init(endpoint: .unix(path: socketPath), database: database, eventLoopGroup: eventLoopGroup, logger: logger)
     }
     
     // MARK: - Connection Management

--- a/Sources/SwiftOVN/Managers/OVSManager.swift
+++ b/Sources/SwiftOVN/Managers/OVSManager.swift
@@ -7,14 +7,18 @@ public actor OVSManager: OVSManaging {
     private let logger: Logger
     private let database: String
     
-    public init(socketPath: String, database: String = OVSDatabase.openVSwitch, eventLoopGroup: EventLoopGroup? = nil, logger: Logger? = nil) {
+    public init(endpoint: OVSDBEndpoint, database: String = OVSDatabase.openVSwitch, eventLoopGroup: EventLoopGroup? = nil, logger: Logger? = nil) {
         self.connection = OVSDBConnection(
-            socketPath: socketPath,
+            endpoint: endpoint,
             eventLoopGroup: eventLoopGroup,
             logger: logger
         )
         self.database = database
         self.logger = logger ?? Logger(label: "ovn-manager.ovs")
+    }
+
+    public init(socketPath: String, database: String = OVSDatabase.openVSwitch, eventLoopGroup: EventLoopGroup? = nil, logger: Logger? = nil) {
+        self.init(endpoint: .unix(path: socketPath), database: database, eventLoopGroup: eventLoopGroup, logger: logger)
     }
     
     // MARK: - Connection Management

--- a/Tests/SwiftOVNTests/OVSDBEndpointTests.swift
+++ b/Tests/SwiftOVNTests/OVSDBEndpointTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import SwiftOVN
+
+final class OVSDBEndpointTests: XCTestCase {
+
+    // MARK: - Parsing
+
+    func testParsesUnixEndpoint() throws {
+        let endpoint = try OVSDBEndpoint(parsing: "unix:/var/run/ovn/ovnnb_db.sock")
+        XCTAssertEqual(endpoint, .unix(path: "/var/run/ovn/ovnnb_db.sock"))
+    }
+
+    func testParsesTCPEndpoint() throws {
+        let endpoint = try OVSDBEndpoint(parsing: "tcp:central.example.com:6641")
+        XCTAssertEqual(endpoint, .tcp(host: "central.example.com", port: 6641))
+    }
+
+    func testParsesTCPEndpointWithIPv4Host() throws {
+        let endpoint = try OVSDBEndpoint(parsing: "tcp:192.0.2.10:6642")
+        XCTAssertEqual(endpoint, .tcp(host: "192.0.2.10", port: 6642))
+    }
+
+    func testParsesBracketedIPv6Host() throws {
+        let endpoint = try OVSDBEndpoint(parsing: "tcp:[2001:db8::1]:6641")
+        XCTAssertEqual(endpoint, .tcp(host: "2001:db8::1", port: 6641))
+    }
+
+    func testParsesSSLEndpointWithDefaultTLSConfiguration() throws {
+        let endpoint = try OVSDBEndpoint(parsing: "ssl:central.example.com:6642")
+        XCTAssertEqual(endpoint, .ssl(host: "central.example.com", port: 6642, tls: OVSDBTLSConfiguration()))
+    }
+
+    func testRejectsUnknownScheme() {
+        XCTAssertThrowsError(try OVSDBEndpoint(parsing: "udp:host:6641"))
+    }
+
+    func testRejectsMissingScheme() {
+        XCTAssertThrowsError(try OVSDBEndpoint(parsing: "/var/run/ovn/ovnnb_db.sock"))
+    }
+
+    func testRejectsMissingPort() {
+        XCTAssertThrowsError(try OVSDBEndpoint(parsing: "tcp:hostonly"))
+        XCTAssertThrowsError(try OVSDBEndpoint(parsing: "tcp:[2001:db8::1]"))
+    }
+
+    func testRejectsInvalidPort() {
+        XCTAssertThrowsError(try OVSDBEndpoint(parsing: "tcp:host:notaport"))
+        XCTAssertThrowsError(try OVSDBEndpoint(parsing: "tcp:host:0"))
+        XCTAssertThrowsError(try OVSDBEndpoint(parsing: "tcp:host:70000"))
+    }
+
+    func testRejectsEmptyHost() {
+        XCTAssertThrowsError(try OVSDBEndpoint(parsing: "tcp::6641"))
+    }
+
+    func testRejectsEmptyUnixPath() {
+        XCTAssertThrowsError(try OVSDBEndpoint(parsing: "unix:"))
+    }
+
+    // MARK: - Description round trip
+
+    func testDescriptionRoundTrips() throws {
+        let strings = [
+            "unix:/var/run/ovn/ovnnb_db.sock",
+            "tcp:central.example.com:6641",
+            "tcp:[2001:db8::1]:6641",
+            "ssl:central.example.com:6642"
+        ]
+        for string in strings {
+            let endpoint = try OVSDBEndpoint(parsing: string)
+            XCTAssertEqual(endpoint.description, string)
+            XCTAssertEqual(try OVSDBEndpoint(parsing: endpoint.description), endpoint)
+        }
+    }
+
+    // MARK: - Defaults
+
+    func testDefaultPorts() {
+        XCTAssertEqual(OVSDBEndpoint.defaultNorthboundPort, 6641)
+        XCTAssertEqual(OVSDBEndpoint.defaultSouthboundPort, 6642)
+    }
+
+    func testSSLConvenienceUsesDefaultTLSConfiguration() {
+        XCTAssertEqual(
+            OVSDBEndpoint.ssl(host: "h", port: 6642),
+            .ssl(host: "h", port: 6642, tls: OVSDBTLSConfiguration())
+        )
+    }
+}

--- a/Tests/SwiftOVNTests/TCPTransportTests.swift
+++ b/Tests/SwiftOVNTests/TCPTransportTests.swift
@@ -95,8 +95,9 @@ final class TCPTransportTests: XCTestCase {
 
 /// Answers `echo` and `list_dbs` requests the way ovsdb-server would.
 /// Assumes each inbound read contains exactly one JSON-RPC object, which
-/// holds for the sequential requests these tests issue.
-private final class JSONRPCStubServerHandler: ChannelInboundHandler, @unchecked Sendable {
+/// holds for the sequential requests these tests issue. Shared with
+/// `TLSTransportTests`.
+final class JSONRPCStubServerHandler: ChannelInboundHandler, @unchecked Sendable {
     typealias InboundIn = ByteBuffer
     typealias OutboundOut = ByteBuffer
 

--- a/Tests/SwiftOVNTests/TCPTransportTests.swift
+++ b/Tests/SwiftOVNTests/TCPTransportTests.swift
@@ -34,8 +34,8 @@ final class TCPTransportTests: XCTestCase {
     }
 
     func testJSONRPCClientOverTCP() async throws {
+        // No explicit server cleanup: tearDown's group shutdown closes it.
         let server = try await startServer()
-        defer { try? server.close().wait() }
         let port = try XCTUnwrap(server.localAddress?.port)
 
         let client = JSONRPCClient(
@@ -59,7 +59,6 @@ final class TCPTransportTests: XCTestCase {
         // OVSDBConnection.connect() performs the initial echo handshake, so a
         // successful connect proves the full request/response path over TCP.
         let server = try await startServer()
-        defer { try? server.close().wait() }
         let port = try XCTUnwrap(server.localAddress?.port)
 
         let connection = OVSDBConnection(

--- a/Tests/SwiftOVNTests/TCPTransportTests.swift
+++ b/Tests/SwiftOVNTests/TCPTransportTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+import NIO
+import NIOPosix
+import Logging
+@testable import SwiftOVN
+
+/// End-to-end tests for the TCP transport: a minimal in-process JSON-RPC
+/// server accepts a real TCP connection from the client and answers `echo`
+/// and `list_dbs`, exercising the same pipeline used against a remote
+/// ovsdb-server (`tcp:<host>:6641/6642`).
+final class TCPTransportTests: XCTestCase {
+
+    private var group: MultiThreadedEventLoopGroup!
+
+    override func setUp() {
+        super.setUp()
+        group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    }
+
+    override func tearDown() {
+        try? group.syncShutdownGracefully()
+        group = nil
+        super.tearDown()
+    }
+
+    private func startServer() async throws -> Channel {
+        return try await ServerBootstrap(group: group)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .childChannelInitializer { channel in
+                channel.pipeline.addHandler(JSONRPCStubServerHandler())
+            }
+            .bind(host: "127.0.0.1", port: 0)
+            .get()
+    }
+
+    func testJSONRPCClientOverTCP() async throws {
+        let server = try await startServer()
+        defer { try? server.close().wait() }
+        let port = try XCTUnwrap(server.localAddress?.port)
+
+        let client = JSONRPCClient(
+            endpoint: .tcp(host: "127.0.0.1", port: port),
+            eventLoopGroup: group
+        )
+        try await client.connect()
+        XCTAssertTrue(client.isConnected)
+
+        let echoed = try await client.echo()
+        XCTAssertEqual(echoed, ["echo"])
+
+        let databases = try await client.listDatabases()
+        XCTAssertEqual(databases, ["OVN_Northbound", "OVN_Southbound"])
+
+        try await client.disconnect()
+        XCTAssertFalse(client.isConnected)
+    }
+
+    func testOVSDBConnectionOverTCP() async throws {
+        // OVSDBConnection.connect() performs the initial echo handshake, so a
+        // successful connect proves the full request/response path over TCP.
+        let server = try await startServer()
+        defer { try? server.close().wait() }
+        let port = try XCTUnwrap(server.localAddress?.port)
+
+        let connection = OVSDBConnection(
+            endpoint: .tcp(host: "127.0.0.1", port: port),
+            eventLoopGroup: group
+        )
+        try await connection.connect()
+        let isConnected = await connection.isConnected
+        XCTAssertTrue(isConnected)
+        try await connection.disconnect()
+    }
+
+    func testConnectFailsWhenNothingIsListening() async throws {
+        // Bind and immediately close to obtain a port with no listener.
+        let server = try await startServer()
+        let port = try XCTUnwrap(server.localAddress?.port)
+        try await server.close()
+
+        let client = JSONRPCClient(
+            endpoint: .tcp(host: "127.0.0.1", port: port),
+            eventLoopGroup: group
+        )
+        do {
+            try await client.connect()
+            XCTFail("Expected connection to fail")
+        } catch {
+            guard case OVNManagerError.connectionFailed = error else {
+                XCTFail("Expected connectionFailed, got \(error)")
+                return
+            }
+        }
+    }
+}
+
+/// Answers `echo` and `list_dbs` requests the way ovsdb-server would.
+/// Assumes each inbound read contains exactly one JSON-RPC object, which
+/// holds for the sequential requests these tests issue.
+private final class JSONRPCStubServerHandler: ChannelInboundHandler, @unchecked Sendable {
+    typealias InboundIn = ByteBuffer
+    typealias OutboundOut = ByteBuffer
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        var buffer = unwrapInboundIn(data)
+        guard let bytes = buffer.readBytes(length: buffer.readableBytes),
+              let request = (try? JSONSerialization.jsonObject(with: Data(bytes))) as? [String: Any],
+              let method = request["method"] as? String else {
+            return
+        }
+
+        let result: Any
+        switch method {
+        case "echo":
+            result = request["params"] ?? [Any]()
+        case "list_dbs":
+            result = ["OVN_Northbound", "OVN_Southbound"]
+        default:
+            result = [String: Any]()
+        }
+
+        let reply: [String: Any] = [
+            "id": request["id"] ?? NSNull(),
+            "result": result,
+            "error": NSNull()
+        ]
+        guard let replyData = try? JSONSerialization.data(withJSONObject: reply) else {
+            return
+        }
+        var out = context.channel.allocator.buffer(capacity: replyData.count)
+        out.writeBytes(replyData)
+        context.writeAndFlush(wrapOutboundOut(out), promise: nil)
+    }
+}

--- a/Tests/SwiftOVNTests/TLSTransportTests.swift
+++ b/Tests/SwiftOVNTests/TLSTransportTests.swift
@@ -1,0 +1,170 @@
+import XCTest
+import NIO
+import NIOPosix
+import NIOSSL
+import Logging
+@testable import SwiftOVN
+
+/// End-to-end tests for the `ssl:` transport against an in-process NIOSSL
+/// server using a self-signed certificate whose SANs cover `localhost` and
+/// `127.0.0.1`. Also verifies that `connect()` reflects the TLS handshake
+/// outcome instead of resolving at TCP establishment.
+final class TLSTransportTests: XCTestCase {
+
+    private var group: MultiThreadedEventLoopGroup!
+    private var caFilePath: String!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        // The client API takes the CA as a PEM file path.
+        let caFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("swiftovn-test-ca-\(UUID().uuidString).pem")
+        try Self.certificatePEM.write(to: caFile, atomically: true, encoding: .utf8)
+        caFilePath = caFile.path
+    }
+
+    override func tearDown() {
+        try? group.syncShutdownGracefully()
+        group = nil
+        if let caFilePath {
+            try? FileManager.default.removeItem(atPath: caFilePath)
+        }
+        caFilePath = nil
+        super.tearDown()
+    }
+
+    private func startTLSServer() async throws -> Channel {
+        let certificate = try NIOSSLCertificate(bytes: Array(Self.certificatePEM.utf8), format: .pem)
+        let privateKey = try NIOSSLPrivateKey(bytes: Array(Self.privateKeyPEM.utf8), format: .pem)
+        let configuration = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(certificate)],
+            privateKey: .privateKey(privateKey)
+        )
+        let sslContext = try NIOSSLContext(configuration: configuration)
+
+        return try await ServerBootstrap(group: group)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .childChannelInitializer { channel in
+                channel.pipeline.addHandlers([
+                    NIOSSLServerHandler(context: sslContext),
+                    JSONRPCStubServerHandler()
+                ])
+            }
+            .bind(host: "127.0.0.1", port: 0)
+            .get()
+    }
+
+    func testHandshakeAndEchoWithTrustedCA() async throws {
+        // The client connects by IP with no serverHostname, so a passing
+        // handshake also proves NIOSSL's IP-SAN identity verification path.
+        let server = try await startTLSServer()
+        let port = try XCTUnwrap(server.localAddress?.port)
+
+        let tls = OVSDBTLSConfiguration(caCertificatePath: caFilePath)
+        let client = JSONRPCClient(
+            endpoint: .ssl(host: "127.0.0.1", port: port, tls: tls),
+            eventLoopGroup: group
+        )
+        try await client.connect()
+        XCTAssertTrue(client.isConnected)
+
+        let echoed = try await client.echo()
+        XCTAssertEqual(echoed, ["echo"])
+
+        try await client.disconnect()
+    }
+
+    func testConnectFailsWhenCertificateIsUntrusted() async throws {
+        // Without our CA in the trust roots the handshake must fail, and that
+        // failure must surface from connect() itself — not from a later
+        // request — since verification happens after the TCP connect.
+        let server = try await startTLSServer()
+        let port = try XCTUnwrap(server.localAddress?.port)
+
+        let client = JSONRPCClient(
+            endpoint: .ssl(host: "127.0.0.1", port: port, tls: OVSDBTLSConfiguration()),
+            eventLoopGroup: group
+        )
+        do {
+            try await client.connect()
+            XCTFail("Expected TLS handshake to fail against an untrusted certificate")
+        } catch {
+            guard case OVNManagerError.connectionFailed = error else {
+                XCTFail("Expected connectionFailed, got \(error)")
+                return
+            }
+        }
+        XCTAssertFalse(client.isConnected)
+    }
+
+    func testDisabledVerificationConnects() async throws {
+        let server = try await startTLSServer()
+        let port = try XCTUnwrap(server.localAddress?.port)
+
+        let tls = OVSDBTLSConfiguration(verifiesServerCertificate: false)
+        let client = JSONRPCClient(
+            endpoint: .ssl(host: "127.0.0.1", port: port, tls: tls),
+            eventLoopGroup: group
+        )
+        try await client.connect()
+        let echoed = try await client.echo()
+        XCTAssertEqual(echoed, ["echo"])
+        try await client.disconnect()
+    }
+
+    // MARK: - Fixtures
+
+    /// Self-signed certificate, CN=localhost, SANs DNS:localhost and
+    /// IP:127.0.0.1, valid for 100 years from 2026-07-08.
+    private static let certificatePEM = """
+        -----BEGIN CERTIFICATE-----
+        MIICyzCCAbOgAwIBAgIJAPQPBrejKTVtMA0GCSqGSIb3DQEBCwUAMBQxEjAQBgNV
+        BAMMCWxvY2FsaG9zdDAgFw0yNjA3MDgyMjMyNDNaGA8yMTI2MDYxNDIyMzI0M1ow
+        FDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
+        CgKCAQEA24Kh/EWoassVpdt6xO5hJQeBa1hKHuhz71AjXf1o6KCTcsLGZf9pRi7i
+        Rb88qcxaw9TF39BQjF8+JwgMLi1Eu4o9G+jG6mXnUeLjGxKIxLGS+kHAsdaWlE0B
+        3vmfFOCQOLkous34ATs9+qznEzC8AJGKqislDbL5TIT2xmvnyN+9Qo/mZa2hoDTL
+        22mrSSrtUGnZuRETjh+PiTL1w0C/rxaVTMSi1WQtyuai4axV5mlzEFtHBacsFxwR
+        zv6HGeGeZVC9Qmzs99wjPB82de0xPMfxru1pNkQeeC/I1tmo1PX/q9FAqFW/Kzud
+        xZcwlKVm9Q5bTxjzv1MwUbYGb1oX2wIDAQABox4wHDAaBgNVHREEEzARgglsb2Nh
+        bGhvc3SHBH8AAAEwDQYJKoZIhvcNAQELBQADggEBADhtVmpg+K+fJY9syksBxW/n
+        EMC2izoqKyvRcKoTbMlQjxAsMD/NUnqGbERGjXIf3xE5GHBuDsMXP8a4+wnvAmVB
+        5m4+CfEoQYzjpmsdi80xIsXf5dDHG4UunVqtaka2sShWSCOsHeV5MshXJUtZZZD8
+        ZgaqwR1F2yCM7xlSZQFuXXn15jbljiPTTNZbi1+7JMUJTXzeWxv/SeVOius/dBuo
+        9mT78PtzSNuuaDToS2V7Npy3PituT5JHT2vZmgavv5/4lAMwiRbsWD5wNy5b5n6e
+        WsYPg0NReXoXiV0mAO54sszjShGbB4qZBhZv1XJJy5Nz90PuF1moeSjf4femERo=
+        -----END CERTIFICATE-----
+        """
+
+    private static let privateKeyPEM = """
+        -----BEGIN PRIVATE KEY-----
+        MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDbgqH8RahqyxWl
+        23rE7mElB4FrWEoe6HPvUCNd/WjooJNywsZl/2lGLuJFvzypzFrD1MXf0FCMXz4n
+        CAwuLUS7ij0b6MbqZedR4uMbEojEsZL6QcCx1paUTQHe+Z8U4JA4uSi6zfgBOz36
+        rOcTMLwAkYqqKyUNsvlMhPbGa+fI371Cj+ZlraGgNMvbaatJKu1Qadm5EROOH4+J
+        MvXDQL+vFpVMxKLVZC3K5qLhrFXmaXMQW0cFpywXHBHO/ocZ4Z5lUL1CbOz33CM8
+        HzZ17TE8x/Gu7Wk2RB54L8jW2ajU9f+r0UCoVb8rO53FlzCUpWb1DltPGPO/UzBR
+        tgZvWhfbAgMBAAECggEAYZF9Aq7LnzxJkQEvXp0+XMErS1VhDL/x2CtcrQhYOx40
+        q8vbd7bBSkrIlIveIPMOXQEUOtlTFDG5ZIv1Lgk9Bcb6Ro9+6u0ElqcsnvnsBNGR
+        LN9RETr6j0xzSnLVvOfb8vqKGg428AUvFV8JDsSYrAAFDIJE5APrP5HSRnvr+KJ3
+        hqYqhQivpQg9c3KGG/pcAu2JBsmzC7vhDTzmR9Qj+nODE5yBdPu9iz8w67JemEN/
+        D1Ypuh7HHoU8DcWOYjSMwRZG/lahHyTIUiKEqENjY500z/7rrDF5hCKkUPkJ4Wc9
+        li04aQ7z5IZ1Aleob+GdObICCNRftYNgWjmIVwmyAQKBgQD3TDKme/o23zolw44P
+        qpHV4s3jmmPkUznfMAJNgcLQ/WVWsQ4okPt/izYVcU60rjX1TA1MMWb449Sl4c3Q
+        M5cx3Ddc8QfjGX8uxylMQRbbtW7PxhdPJfNowNWuCmoMsrmzNDZhOlLskxbVG2YQ
+        SVt1iPl/RVNQ5/ZQKG+EMqwMgQKBgQDjPBwr74IOevSvqFF/H7FCVp+QoYa6lKJU
+        SoOju3fjSCaSMRAgFlkn9ODMVkVjrdbMpG2JonzT30dCI3y2ntWjV4ZQXuoLNNb5
+        kERVbttCL5WFaproUBKCcwf73hac+ThRV0rgo9pjeyO7vTikWXj3vPmH1waBe3bE
+        TmFTSRamWwKBgDNqmlVXDYz/GJ3lbNIBCtVHlLsvzHkafLvUxYXL5u+A3+MIaQMy
+        Mbgw/4uxxUV3uyxHJbSjyN8Sr5HVwu746wSo3rHqQ1OKZ5EYQ5PhLJl9vY5hh1Mj
+        dtpezY6kB6ygNE/4GR5Z/AfIBUVFrxDPz74+PnGhvlLiB6pe3eDEkFUBAoGAanSr
+        wg2YAY6q+WxCmerQEYMhiBGUW+7sSc8K8vcNyIXxxAWGR3IQ3L5FXpWANp2nhwH1
+        a0ibcGsnKB4V/DxXXAnSG+8LeKqNmCd1TAz+XXiLdRCnd/SjZ0fa0q2OLIY5Uyox
+        IyLAWmDDMd4JHj3ohS+cO36KRrj/wCH0SJ9yJAcCgYAMd0YU/t+lfDngHVYf2osV
+        tCRFArFzXqtR+m7jkfI+oi8eWY/CTMswTheW7lTyo32j8UwVrm08mZKCxdk/S/nV
+        iSuQFW0+n+jYlQzRLCXyr1Efy9iZWK2ATSXJ9w4KxJvcPeJ4tw3sba1SY5882V7k
+        i43Yy+DkAVej08C+p+wExg==
+        -----END PRIVATE KEY-----
+        """
+}


### PR DESCRIPTION
Closes #19

## What

The client could only reach a database over a local Unix socket, so an `OVNManager` could never talk to a shared/central northbound DB. This adds remote transports:

- **`OVSDBEndpoint`** — `.unix(path:)`, `.tcp(host:port:)`, `.ssl(host:port:tls:)`, plus parsing of OVN-style connection strings (`tcp:host:6641`, `ssl:...`, bracketed IPv6) and default NB/SB port constants (6641/6642).
- **`OVSDBTLSConfiguration`** — CA cert, client cert/key (PEM paths, matching what `ovn-pki` produces), optional verification opt-out and SNI hostname override. TLS is implemented with NIOSSL; IP-literal hosts are handled (no SNI).
- **`OVSDBTransport`** protocol with `OVSDBSocketConnection` as the implementation covering all three transports. `JSONRPCClient` also accepts a caller-supplied transport (useful for mocks).

## Source compatibility

- `UnixSocketConnection` remains as a typealias of `OVSDBSocketConnection`.
- All existing `socketPath:` initializers on `JSONRPCClient`, `OVSDBConnection`, `OVNManager`, `OVSManager` are unchanged and delegate to `.unix(path:)`.

## Testing

- `OVSDBEndpointTests`: connection-string parsing (valid/invalid, IPv6, description round trip).
- `TCPTransportTests`: real TCP loopback against an in-process JSON-RPC stub server — full connect/echo/list_dbs/disconnect through `JSONRPCClient` and the `OVSDBConnection` handshake, plus a connection-refused failure path.
- Full suite: 83 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)