### PR TITLE
Add Port_Group model + CRUD (security groups)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ The package includes comprehensive Swift models for:
 - `OVNLogicalRouter` - Virtual routers
 - `OVNLogicalRouterPort` - Ports on logical routers
 - `OVNACL` - Access control lists
+- `OVNPortGroup` - Port groups for scalable security-group ACLs
 - `OVNLoadBalancer` - Load balancing rules
 - `OVNNAT` - Network address translation rules
 - `OVNDHCPOptions` - DHCP configuration

--- a/Sources/SwiftOVN/Managers/OVNManager.swift
+++ b/Sources/SwiftOVN/Managers/OVNManager.swift
@@ -677,8 +677,8 @@ public actor OVNManager: OVNManaging {
 
     /// Adds logical switch ports to the group's membership without rewriting
     /// the whole `ports` set, mirroring `ovn-nbctl pg-set-ports` incrementally.
-    /// `ports` is a weak reference set, so a UUID whose port row no longer
-    /// exists at commit is silently dropped rather than rejected.
+    /// Throws if any requested port no longer exists, so a stale UUID can't be
+    /// silently dropped from this weak reference set (see `mutatePorts`).
     public func addPorts(_ portUUIDs: [String], toPortGroup name: String) async throws {
         try await mutatePorts(portUUIDs, portGroup: name, mutator: "insert")
     }
@@ -1094,23 +1094,52 @@ private extension OVNManager {
     /// Inserts or deletes a set of Logical_Switch_Port UUIDs in a port
     /// group's `ports` column via a single mutate op. A no-op (empty UUID
     /// list) is skipped so the caller never issues an empty mutation.
+    ///
+    /// `Port_Group.ports` is a weak reference set: ovsdb-server silently drops
+    /// a UUID whose Logical_Switch_Port no longer exists at commit, so an
+    /// `insert` of a stale UUID would report the port group matched while
+    /// applying no membership change. For inserts we therefore guard each
+    /// added port with a same-transaction wait op that aborts the transaction
+    /// unless the port row still exists at commit (mirroring the load-balancer
+    /// attach guard). Deletes need no such guard — removing a stale UUID is a
+    /// harmless no-op.
     func mutatePorts(_ portUUIDs: [String], portGroup name: String, mutator: String) async throws {
         guard !portUUIDs.isEmpty else { return }
 
-        let condition = OVSDBCondition(column: "name", function: "==", value: .string(name))
-        let portSet = JSONValue.array([
-            .string("set"),
-            .array(portUUIDs.map { .array([.string("uuid"), .string($0)]) })
-        ])
+        let portAtoms = portUUIDs.map { JSONValue.array([.string("uuid"), .string($0)]) }
+        let portSet = JSONValue.array([.string("set"), .array(portAtoms)])
 
-        let count = try await connection.mutate(
+        var operations: [OVSDBOperation] = []
+        if mutator == "insert" {
+            for uuid in portUUIDs {
+                let portCondition = OVSDBCondition(column: "_uuid", function: "==", value: .array([.string("uuid"), .string(uuid)]))
+                operations.append(OVSDBOperation(
+                    op: "wait",
+                    table: OVNTable.logicalSwitchPort,
+                    whereConditions: [portCondition],
+                    columns: ["_uuid"],
+                    rows: [],
+                    until: "!=",
+                    timeout: 0
+                ))
+            }
+        }
+
+        let groupCondition = OVSDBCondition(column: "name", function: "==", value: .string(name))
+        operations.append(OVSDBOperation(
+            op: "mutate",
             table: OVNTable.portGroup,
-            in: database,
-            where: [condition],
+            whereConditions: [groupCondition],
             mutations: [OVSDBMutation(column: "ports", mutator: mutator, value: portSet)]
-        )
+        ))
 
-        if count == 0 {
+        let results = try await connection.transact(in: database, operations: operations)
+
+        guard case .object(let mutateResult)? = results.last,
+              case .number(let count)? = mutateResult["count"] else {
+            throw OVNManagerError.invalidResponse("Invalid mutate response format")
+        }
+        if Int(count) == 0 {
             throw OVNManagerError.operationFailed("Port group not found: \(name)")
         }
     }

--- a/Sources/SwiftOVN/Managers/OVNManager.swift
+++ b/Sources/SwiftOVN/Managers/OVNManager.swift
@@ -598,7 +598,119 @@ public actor OVNManager: OVNManaging {
 
         logger.info("Deleted ACL: \(uuid)")
     }
-    
+
+    // MARK: - Port Group Operations
+
+    public func getPortGroups() async throws -> [OVNPortGroup] {
+        let rows = try await connection.selectAll(from: OVNTable.portGroup, in: database)
+        return try rows.compactMap { row in
+            try parseRow(row, as: OVNPortGroup.self)
+        }
+    }
+
+    public func getPortGroup(named name: String) async throws -> OVNPortGroup? {
+        let condition = OVSDBCondition(column: "name", function: "==", value: .string(name))
+        let rows = try await connection.select(from: OVNTable.portGroup, in: database, where: [condition])
+
+        guard let firstRow = rows.first else { return nil }
+        return try parseRow(firstRow, as: OVNPortGroup.self)
+    }
+
+    /// Creates a port group, mirroring `ovn-nbctl pg-add`. Port_Group is a
+    /// root table, so the row persists until it is explicitly deleted.
+    public func createPortGroup(_ portGroup: OVNPortGroup) async throws -> String {
+        let nameCondition = OVSDBCondition(column: "name", function: "==", value: .string(portGroup.name))
+
+        guard try await rowUUID(in: OVNTable.portGroup, where: nameCondition) == nil else {
+            throw OVNManagerError.operationFailed("Port group already exists: \(portGroup.name)")
+        }
+
+        let row = try createRow(from: portGroup)
+
+        // Guard against a duplicate name racing in between the check above and
+        // the insert: the wait op aborts the transaction unless no row with
+        // this name still exists at commit.
+        let operations = [
+            OVSDBOperation(
+                op: "wait",
+                table: OVNTable.portGroup,
+                whereConditions: [nameCondition],
+                columns: ["name"],
+                rows: [],
+                until: "==",
+                timeout: 0
+            ),
+            OVSDBOperation(
+                op: "insert",
+                table: OVNTable.portGroup,
+                row: row
+            )
+        ]
+
+        let results = try await connection.transact(in: database, operations: operations)
+
+        guard results.count >= 2,
+              case .object(let insertResult) = results[1],
+              let uuid = insertResult["uuid"],
+              case .array(let uuidArray) = uuid,
+              uuidArray.count == 2,
+              case .string(let uuidValue) = uuidArray[1] else {
+            throw OVNManagerError.invalidResponse("Invalid UUID in insert response")
+        }
+
+        logger.info("Created port group: \(portGroup.name)")
+        return uuidValue
+    }
+
+    public func updatePortGroup(uuid: String, _ portGroup: OVNPortGroup) async throws {
+        let condition = OVSDBCondition(column: "_uuid", function: "==", value: .array([.string("uuid"), .string(uuid)]))
+        let row = try createRow(from: portGroup)
+
+        let count = try await connection.update(table: OVNTable.portGroup, in: database, where: [condition], row: row)
+
+        if count == 0 {
+            throw OVNManagerError.operationFailed("Port group not found: \(uuid)")
+        }
+
+        logger.info("Updated port group: \(portGroup.name)")
+    }
+
+    /// Adds logical switch ports to the group's membership without rewriting
+    /// the whole `ports` set, mirroring `ovn-nbctl pg-set-ports` incrementally.
+    /// `ports` is a weak reference set, so a UUID whose port row no longer
+    /// exists at commit is silently dropped rather than rejected.
+    public func addPorts(_ portUUIDs: [String], toPortGroup name: String) async throws {
+        try await mutatePorts(portUUIDs, portGroup: name, mutator: "insert")
+    }
+
+    /// Removes logical switch ports from the group's membership without
+    /// rewriting the whole `ports` set.
+    public func removePorts(_ portUUIDs: [String], fromPortGroup name: String) async throws {
+        try await mutatePorts(portUUIDs, portGroup: name, mutator: "delete")
+    }
+
+    public func deletePortGroup(uuid: String) async throws {
+        let condition = OVSDBCondition(column: "_uuid", function: "==", value: .array([.string("uuid"), .string(uuid)]))
+        let count = try await connection.delete(from: OVNTable.portGroup, in: database, where: [condition])
+
+        if count == 0 {
+            throw OVNManagerError.operationFailed("Port group not found: \(uuid)")
+        }
+
+        logger.info("Deleted port group: \(uuid)")
+    }
+
+    public func deletePortGroup(named name: String) async throws {
+        let condition = OVSDBCondition(column: "name", function: "==", value: .string(name))
+        let count = try await connection.delete(from: OVNTable.portGroup, in: database, where: [condition])
+
+        if count == 0 {
+            throw OVNManagerError.operationFailed("Port group not found: \(name)")
+        }
+
+        logger.info("Deleted port group: \(name)")
+    }
+
     // MARK: - Load Balancer Operations
     
     public func getLoadBalancers() async throws -> [OVNLoadBalancer] {
@@ -976,6 +1088,30 @@ private extension OVNManager {
 
         if count == 0 {
             throw OVNManagerError.operationFailed("\(parentDescription) not found: \(parentName)")
+        }
+    }
+
+    /// Inserts or deletes a set of Logical_Switch_Port UUIDs in a port
+    /// group's `ports` column via a single mutate op. A no-op (empty UUID
+    /// list) is skipped so the caller never issues an empty mutation.
+    func mutatePorts(_ portUUIDs: [String], portGroup name: String, mutator: String) async throws {
+        guard !portUUIDs.isEmpty else { return }
+
+        let condition = OVSDBCondition(column: "name", function: "==", value: .string(name))
+        let portSet = JSONValue.array([
+            .string("set"),
+            .array(portUUIDs.map { .array([.string("uuid"), .string($0)]) })
+        ])
+
+        let count = try await connection.mutate(
+            table: OVNTable.portGroup,
+            in: database,
+            where: [condition],
+            mutations: [OVSDBMutation(column: "ports", mutator: mutator, value: portSet)]
+        )
+
+        if count == 0 {
+            throw OVNManagerError.operationFailed("Port group not found: \(name)")
         }
     }
 

--- a/Sources/SwiftOVN/Managers/OVNManager.swift
+++ b/Sources/SwiftOVN/Managers/OVNManager.swift
@@ -627,30 +627,35 @@ public actor OVNManager: OVNManaging {
 
         let row = try createRow(from: portGroup)
 
+        // `ports` is a weak reference set, so any initial member whose port row
+        // is stale at commit would be silently dropped from the insert. Guard
+        // each supplied port so a stale UUID aborts the whole insert instead of
+        // creating a group with missing membership.
+        var operations = portExistenceWaitOps(portGroup.ports ?? [])
+
         // Guard against a duplicate name racing in between the check above and
         // the insert: the wait op aborts the transaction unless no row with
         // this name still exists at commit.
-        let operations = [
-            OVSDBOperation(
-                op: "wait",
-                table: OVNTable.portGroup,
-                whereConditions: [nameCondition],
-                columns: ["name"],
-                rows: [],
-                until: "==",
-                timeout: 0
-            ),
-            OVSDBOperation(
-                op: "insert",
-                table: OVNTable.portGroup,
-                row: row
-            )
-        ]
+        operations.append(OVSDBOperation(
+            op: "wait",
+            table: OVNTable.portGroup,
+            whereConditions: [nameCondition],
+            columns: ["name"],
+            rows: [],
+            until: "==",
+            timeout: 0
+        ))
+        let insertIndex = operations.count
+        operations.append(OVSDBOperation(
+            op: "insert",
+            table: OVNTable.portGroup,
+            row: row
+        ))
 
         let results = try await connection.transact(in: database, operations: operations)
 
-        guard results.count >= 2,
-              case .object(let insertResult) = results[1],
+        guard results.count > insertIndex,
+              case .object(let insertResult) = results[insertIndex],
               let uuid = insertResult["uuid"],
               case .array(let uuidArray) = uuid,
               uuidArray.count == 2,
@@ -666,9 +671,26 @@ public actor OVNManager: OVNManaging {
         let condition = OVSDBCondition(column: "_uuid", function: "==", value: .array([.string("uuid"), .string(uuid)]))
         let row = try createRow(from: portGroup)
 
-        let count = try await connection.update(table: OVNTable.portGroup, in: database, where: [condition], row: row)
+        // A full-row update rewrites the weak-reference `ports` set, so guard
+        // each supplied port the same way create/mutate do: a stale UUID aborts
+        // the update rather than being silently dropped from the new set.
+        var operations = portExistenceWaitOps(portGroup.ports ?? [])
+        let updateIndex = operations.count
+        operations.append(OVSDBOperation(
+            op: "update",
+            table: OVNTable.portGroup,
+            whereConditions: [condition],
+            row: row
+        ))
 
-        if count == 0 {
+        let results = try await connection.transact(in: database, operations: operations)
+
+        guard results.count > updateIndex,
+              case .object(let updateResult) = results[updateIndex],
+              case .number(let count)? = updateResult["count"] else {
+            throw OVNManagerError.invalidResponse("Invalid update response format")
+        }
+        if Int(count) == 0 {
             throw OVNManagerError.operationFailed("Port group not found: \(uuid)")
         }
 
@@ -1109,21 +1131,8 @@ private extension OVNManager {
         let portAtoms = portUUIDs.map { JSONValue.array([.string("uuid"), .string($0)]) }
         let portSet = JSONValue.array([.string("set"), .array(portAtoms)])
 
-        var operations: [OVSDBOperation] = []
-        if mutator == "insert" {
-            for uuid in portUUIDs {
-                let portCondition = OVSDBCondition(column: "_uuid", function: "==", value: .array([.string("uuid"), .string(uuid)]))
-                operations.append(OVSDBOperation(
-                    op: "wait",
-                    table: OVNTable.logicalSwitchPort,
-                    whereConditions: [portCondition],
-                    columns: ["_uuid"],
-                    rows: [],
-                    until: "!=",
-                    timeout: 0
-                ))
-            }
-        }
+        // Deletes need no guard — removing a stale UUID is a harmless no-op.
+        var operations = mutator == "insert" ? portExistenceWaitOps(portUUIDs) : []
 
         let groupCondition = OVSDBCondition(column: "name", function: "==", value: .string(name))
         operations.append(OVSDBOperation(
@@ -1141,6 +1150,26 @@ private extension OVNManager {
         }
         if Int(count) == 0 {
             throw OVNManagerError.operationFailed("Port group not found: \(name)")
+        }
+    }
+
+    /// Builds a `wait` op per port UUID that aborts the enclosing transaction
+    /// unless that `Logical_Switch_Port` still exists at commit. `Port_Group`'s
+    /// `ports` is a weak reference set, so ovsdb-server would otherwise silently
+    /// drop a stale UUID and report the write as succeeding. Used by any
+    /// transaction that writes the `ports` column (create, update, mutate).
+    func portExistenceWaitOps(_ portUUIDs: [String]) -> [OVSDBOperation] {
+        portUUIDs.map { uuid in
+            let portCondition = OVSDBCondition(column: "_uuid", function: "==", value: .array([.string("uuid"), .string(uuid)]))
+            return OVSDBOperation(
+                op: "wait",
+                table: OVNTable.logicalSwitchPort,
+                whereConditions: [portCondition],
+                columns: ["_uuid"],
+                rows: [],
+                until: "!=",
+                timeout: 0
+            )
         }
     }
 

--- a/Sources/SwiftOVN/Models/OVNPortGroup.swift
+++ b/Sources/SwiftOVN/Models/OVNPortGroup.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// A row in the OVN Northbound `Port_Group` table. Port groups collect a set
+/// of logical switch ports so ACLs can be applied to the group as a whole,
+/// which is OVN's scalable pattern for security groups (mirroring
+/// `ovn-nbctl pg-add`). `Port_Group` is a root table, so a group persists
+/// until it is explicitly deleted.
+public struct OVNPortGroup: Codable, Sendable {
+    public let uuid: String?
+    /// Unique group name. The NB schema indexes this column.
+    public let name: String
+    /// UUIDs of the `Logical_Switch_Port` rows that belong to the group. This
+    /// is a weak reference set: a member whose port row is deleted is dropped
+    /// from the group automatically.
+    public let ports: [String]?
+    /// UUIDs of the `ACL` rows applied to the group.
+    public let acls: [String]?
+    public let external_ids: [String: String]?
+
+    private enum CodingKeys: String, CodingKey {
+        case uuid = "_uuid"
+        case name, ports, acls, external_ids
+    }
+
+    public init(name: String, ports: [String]? = nil, acls: [String]? = nil, external_ids: [String: String]? = nil) {
+        self.uuid = nil
+        self.name = name
+        self.ports = ports
+        self.acls = acls
+        self.external_ids = external_ids
+    }
+}

--- a/Sources/SwiftOVN/Protocols/OVNManaging.swift
+++ b/Sources/SwiftOVN/Protocols/OVNManaging.swift
@@ -67,6 +67,16 @@ public protocol OVNManaging {
     func updateACL(uuid: String, _ acl: OVNACL) async throws
     func deleteACL(uuid: String) async throws
 
+    // Port Group Operations
+    func getPortGroups() async throws -> [OVNPortGroup]
+    func getPortGroup(named name: String) async throws -> OVNPortGroup?
+    func createPortGroup(_ portGroup: OVNPortGroup) async throws -> String
+    func updatePortGroup(uuid: String, _ portGroup: OVNPortGroup) async throws
+    func addPorts(_ portUUIDs: [String], toPortGroup name: String) async throws
+    func removePorts(_ portUUIDs: [String], fromPortGroup name: String) async throws
+    func deletePortGroup(uuid: String) async throws
+    func deletePortGroup(named name: String) async throws
+
     // Load Balancer Operations
     func getLoadBalancers() async throws -> [OVNLoadBalancer]
     func getLoadBalancer(named name: String) async throws -> OVNLoadBalancer?

--- a/Tests/SwiftOVNTests/OVSDBRowCodingTests.swift
+++ b/Tests/SwiftOVNTests/OVSDBRowCodingTests.swift
@@ -368,6 +368,58 @@ final class OVSDBRowEncoderTests: XCTestCase {
         XCTAssertEqual(decoded.external_ids, route.external_ids)
     }
 
+    func testPortGroupReferenceColumnsEncodeUUIDAtoms() throws {
+        let portGroup = OVNPortGroup(
+            name: "pg-web",
+            ports: [uuidB, uuidC],
+            acls: [uuidA],
+            external_ids: ["owner": "test"]
+        )
+
+        let row = try OVSDBRowEncoder.makeRow(from: portGroup, hints: .ovn)
+
+        // ports and acls are reference sets rewritten into UUID atoms; the
+        // encoder always emits the tagged ["set", ...] form, even for one item.
+        XCTAssertEqual(row["ports"], wireSet([wireUUID(uuidB), wireUUID(uuidC)]))
+        XCTAssertEqual(row["acls"], wireSet([wireUUID(uuidA)]))
+        XCTAssertEqual(row["name"], .string("pg-web"))
+        XCTAssertNil(row["_uuid"])
+    }
+
+    func testPortGroupRoundTrip() throws {
+        let portGroup = OVNPortGroup(
+            name: "pg-db",
+            ports: [uuidB, uuidC],
+            acls: [uuidA],
+            external_ids: ["owner": "test"]
+        )
+
+        let row = try OVSDBRowEncoder.makeRow(from: portGroup, hints: .ovn)
+        let decoded = try OVSDBRowDecoder.decode(OVNPortGroup.self, from: row)
+
+        XCTAssertEqual(decoded.name, portGroup.name)
+        XCTAssertEqual(decoded.ports, portGroup.ports)
+        XCTAssertEqual(decoded.acls, portGroup.acls)
+        XCTAssertEqual(decoded.external_ids, portGroup.external_ids)
+    }
+
+    /// A fresh, empty port group has its reference sets sent as the empty set,
+    /// which decodes to nil rather than an empty array.
+    func testPortGroupWithEmptyMembership() throws {
+        let row: OVSDBRow = [
+            "_uuid": wireUUID(uuidA),
+            "name": .string("pg-empty"),
+            "ports": emptySet,
+            "acls": emptySet,
+        ]
+
+        let portGroup = try OVSDBRowDecoder.decode(OVNPortGroup.self, from: row)
+
+        XCTAssertEqual(portGroup.name, "pg-empty")
+        XCTAssertNil(portGroup.ports)
+        XCTAssertNil(portGroup.acls)
+    }
+
     func testDHCPOptionsRoundTrip() throws {
         let dhcp = OVNDHCPOptions(
             cidr: "10.0.0.0/24",


### PR DESCRIPTION
Closes #21.

## What

`OVNTable.portGroup` and `createACL(_:onPortGroup:)` already existed, but there was no `Port_Group` model and no way to create/read/update/delete the group itself — so you could attach ACLs to a port group you couldn't create through the library. This adds that.

## Changes

- **`OVNPortGroup` model** — `name`, `ports` (Logical_Switch_Port UUID refs), `acls` (ACL UUID refs), `external_ids`.
- **CRUD on `OVNManager`**:
  - `getPortGroups()` / `getPortGroup(named:)`
  - `createPortGroup(_:)` — root-table insert with the same wait-op dedup guard used by `createLogicalSwitch`
  - `updatePortGroup(uuid:_:)`
  - `deletePortGroup(uuid:)` / `deletePortGroup(named:)`
- **Incremental membership**: `addPorts(_:toPortGroup:)` / `removePorts(_:fromPortGroup:)` mutate the `ports` set rather than rewriting the whole column.
- Protocol methods added to `OVNManaging`.
- `ports`/`acls` are already in the `.ovn` reference-column hints, so they encode as `["uuid", …]` atoms with no encoder change.
- Tests: reference-column encoding, round trip, and empty-membership decode. Full suite: 91 passing.

## Why

OVN's scalable security-group pattern applies ACLs to Port_Groups rather than per-port. Needed for Strato security-group support (samcat116/strato#341).