### PR TITLE
Clean up connection lifecycle, JSONValue helpers, and API typing (#14)

### DIFF
--- a/Sources/SwiftOVN/Core/JSONRPCClient.swift
+++ b/Sources/SwiftOVN/Core/JSONRPCClient.swift
@@ -47,7 +47,7 @@ public actor JSONRPCClient {
     
     // MARK: - Generic JSON-RPC Methods
     
-    public func call<T: Codable>(
+    public func call<T: Codable & Sendable>(
         method: String,
         params: JSONRPCParams? = nil,
         responseType: T.Type

--- a/Sources/SwiftOVN/Core/OVSDBSocketConnection.swift
+++ b/Sources/SwiftOVN/Core/OVSDBSocketConnection.swift
@@ -10,17 +10,30 @@ public typealias UnixSocketConnection = OVSDBSocketConnection
 
 public final class OVSDBSocketConnection: OVSDBTransport, @unchecked Sendable {
     private let eventLoopGroup: EventLoopGroup
+    /// True when we created `eventLoopGroup` ourselves and are therefore
+    /// responsible for shutting it down; false when the caller injected one.
+    private let ownsEventLoopGroup: Bool
     private let logger: Logger
     private var channel: Channel?
     private let endpoint: OVSDBEndpoint
     private var isConnected: Bool = false
     private var responseRouter: JSONRPCResponseRouter?
+    /// The in-flight `connect()` future, if any. Guards against concurrent
+    /// `connect()` calls each bootstrapping their own channel (which would
+    /// leak all but the last). All access is under `connectionLock`.
+    private var inFlightConnect: EventLoopFuture<Void>?
     private let connectionLock = NSLock()
     private let notificationHub = JSONRPCNotificationHub()
 
     public init(endpoint: OVSDBEndpoint, eventLoopGroup: EventLoopGroup? = nil, logger: Logger? = nil) {
         self.endpoint = endpoint
-        self.eventLoopGroup = eventLoopGroup ?? MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        if let eventLoopGroup {
+            self.eventLoopGroup = eventLoopGroup
+            self.ownsEventLoopGroup = false
+        } else {
+            self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+            self.ownsEventLoopGroup = true
+        }
         self.logger = logger ?? Logger(label: "ovn-manager.socket")
     }
 
@@ -28,17 +41,51 @@ public final class OVSDBSocketConnection: OVSDBTransport, @unchecked Sendable {
         self.init(endpoint: .unix(path: socketPath), eventLoopGroup: eventLoopGroup, logger: logger)
     }
 
+    deinit {
+        // Only shut down a group we created; an injected one is the caller's
+        // to manage. Without this, each connection created with no injected
+        // group leaks its event-loop thread.
+        if ownsEventLoopGroup {
+            try? eventLoopGroup.syncShutdownGracefully()
+        }
+    }
+
     public func connect() -> EventLoopFuture<Void> {
         connectionLock.lock()
-        let alreadyConnected = isConnected
-        connectionLock.unlock()
-
-        guard !alreadyConnected else {
+        if isConnected {
+            connectionLock.unlock()
             logger.debug("Already connected to \(endpoint)")
             return eventLoopGroup.next().makeSucceededFuture(())
         }
+        if let inFlightConnect {
+            connectionLock.unlock()
+            logger.debug("connect() already in progress for \(endpoint), reusing it")
+            return inFlightConnect
+        }
+        let future = makeConnectFuture()
+        // Clear the in-flight slot once this attempt settles so a later
+        // reconnect can start fresh.
+        let deduplicated = future.always { [weak self] _ in
+            guard let self else { return }
+            self.connectionLock.lock()
+            self.inFlightConnect = nil
+            self.connectionLock.unlock()
+        }
+        inFlightConnect = deduplicated
+        connectionLock.unlock()
+        return deduplicated
+    }
 
+    private func makeConnectFuture() -> EventLoopFuture<Void> {
         logger.info("Connecting to OVSDB endpoint: \(endpoint)")
+
+        // Created here (not in the channel initializer) so it can be assigned
+        // to `responseRouter` under the lock once the connection succeeds.
+        let router = JSONRPCResponseRouter(
+            logger: logger,
+            eventLoopGroup: eventLoopGroup,
+            notificationHub: notificationHub
+        )
 
         // TLS state that must exist before the pipeline is built.
         let sslContext: NIOSSLContext?
@@ -75,12 +122,6 @@ public final class OVSDBSocketConnection: OVSDBTransport, @unchecked Sendable {
             .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .channelInitializer { channel in
                 self.logger.debug("Initializing channel pipeline...")
-                let router = JSONRPCResponseRouter(
-                    logger: self.logger,
-                    eventLoopGroup: self.eventLoopGroup,
-                    notificationHub: self.notificationHub
-                )
-                self.responseRouter = router
 
                 var handlers: [ChannelHandler] = []
                 if let sslContext {
@@ -132,6 +173,7 @@ public final class OVSDBSocketConnection: OVSDBTransport, @unchecked Sendable {
                 self.logger.debug("Raw connection established, setting up channel...")
                 self.connectionLock.lock()
                 self.channel = channel
+                self.responseRouter = router
                 self.isConnected = true
                 self.connectionLock.unlock()
                 self.logger.info("Successfully connected to \(self.endpoint)")

--- a/Sources/SwiftOVN/Core/OVSDBSocketConnection.swift
+++ b/Sources/SwiftOVN/Core/OVSDBSocketConnection.swift
@@ -44,9 +44,12 @@ public final class OVSDBSocketConnection: OVSDBTransport, @unchecked Sendable {
     deinit {
         // Only shut down a group we created; an injected one is the caller's
         // to manage. Without this, each connection created with no injected
-        // group leaks its event-loop thread.
+        // group leaks its event-loop thread. Shut down asynchronously: if the
+        // last reference is released by one of the group's own EventLoop
+        // callbacks, `deinit` runs on that EventLoop, where the synchronous
+        // variant would fatally trap.
         if ownsEventLoopGroup {
-            try? eventLoopGroup.syncShutdownGracefully()
+            eventLoopGroup.shutdownGracefully { _ in }
         }
     }
 
@@ -62,18 +65,26 @@ public final class OVSDBSocketConnection: OVSDBTransport, @unchecked Sendable {
             logger.debug("connect() already in progress for \(endpoint), reusing it")
             return inFlightConnect
         }
-        let future = makeConnectFuture()
+        // Reserve the in-flight slot with a promise so concurrent callers
+        // dedup, then release the lock *before* wiring up the real future.
+        // `makeConnectFuture()` can return an already-completed future (missing
+        // socket, invalid TLS); cascading it — and the slot-clearing callback —
+        // would otherwise run synchronously while we still hold the
+        // non-reentrant lock and deadlock when called on the group's EventLoop.
+        let promise = eventLoopGroup.next().makePromise(of: Void.self)
+        inFlightConnect = promise.futureResult
+        connectionLock.unlock()
+
         // Clear the in-flight slot once this attempt settles so a later
         // reconnect can start fresh.
-        let deduplicated = future.always { [weak self] _ in
+        promise.futureResult.whenComplete { [weak self] _ in
             guard let self else { return }
             self.connectionLock.lock()
             self.inFlightConnect = nil
             self.connectionLock.unlock()
         }
-        inFlightConnect = deduplicated
-        connectionLock.unlock()
-        return deduplicated
+        makeConnectFuture().cascade(to: promise)
+        return promise.futureResult
     }
 
     private func makeConnectFuture() -> EventLoopFuture<Void> {

--- a/Sources/SwiftOVN/Extensions/Codable+Extensions.swift
+++ b/Sources/SwiftOVN/Extensions/Codable+Extensions.swift
@@ -14,26 +14,24 @@ extension Array where Element == Int {
     }
 }
 
+// These build the RFC 7047 map wire format (`["map", [[k, v], ...]]`) rather
+// than a plain JSON object, so they can be used directly to construct row
+// column values. Use `JSONValue.map(_:)` for the underlying encoding.
 extension Dictionary where Key == String, Value == String {
     func toJSONValue() -> JSONValue {
-        let mapped = self.mapValues { JSONValue.string($0) }
-        return .object(mapped)
+        return .map(self)
     }
 }
 
 extension Dictionary where Key == String, Value == Int {
     func toJSONValue() -> JSONValue {
-        let mapped = self.mapValues { JSONValue.number(Double($0)) }
-        return .object(mapped)
+        return .map(self)
     }
 }
 
 extension Dictionary where Key == Int, Value == String {
     func toJSONValue() -> JSONValue {
-        let mapped = Dictionary<String, JSONValue>(
-            uniqueKeysWithValues: self.map { (String($0.key), JSONValue.string($0.value)) }
-        )
-        return .object(mapped)
+        return .map(self)
     }
 }
 
@@ -146,47 +144,48 @@ extension JSONValue {
     static func set<T>(_ values: [T]) -> JSONValue where T: Equatable {
         if values.isEmpty {
             return .array([.string("set"), .array([])])
-        } else if values.count == 1 {
-            // Single value sets are represented as just the value
-            if let stringValue = values.first as? String {
-                return .string(stringValue)
-            } else if let intValue = values.first as? Int {
-                return .number(Double(intValue))
-            } else if let doubleValue = values.first as? Double {
-                return .number(doubleValue)
-            }
+        } else if values.count == 1, let scalar = scalarJSONValue(values[0]) {
+            // RFC 7047: a single-element set is sent as the bare scalar.
+            return scalar
         }
-        
-        // Multiple values as a set
-        var jsonArray: [JSONValue] = []
-        for value in values {
-            if let stringValue = value as? String {
-                jsonArray.append(.string(stringValue))
-            } else if let intValue = value as? Int {
-                jsonArray.append(.number(Double(intValue)))
-            } else if let doubleValue = value as? Double {
-                jsonArray.append(.number(doubleValue))
-            }
-        }
-        
+
+        // Multiple values as a set.
+        let jsonArray = values.compactMap { scalarJSONValue($0) }
         return .array([.string("set"), .array(jsonArray)])
     }
-    
-    var setValue: [JSONValue]? {
-        // Handle single value (not wrapped in set)
-        if case .string(_) = self, case .number(_) = self, case .boolean(_) = self {
-            return [self]
+
+    /// Maps a supported scalar element (String, Bool, Int, Double) to a
+    /// `JSONValue`, or `nil` for unsupported types. `Bool` is checked before
+    /// the numeric types because it must not be coerced into a number.
+    private static func scalarJSONValue<T>(_ value: T) -> JSONValue? {
+        if let stringValue = value as? String {
+            return .string(stringValue)
+        } else if let boolValue = value as? Bool {
+            return .boolean(boolValue)
+        } else if let intValue = value as? Int {
+            return .number(Double(intValue))
+        } else if let doubleValue = value as? Double {
+            return .number(doubleValue)
         }
-        
-        // Handle set array format
-        if case .array(let array) = self,
-           array.count == 2,
-           case .string("set") = array[0],
-           case .array(let values) = array[1] {
-            return values
-        }
-        
         return nil
+    }
+
+    var setValue: [JSONValue]? {
+        // A bare scalar is a single-element set (RFC 7047).
+        switch self {
+        case .string, .number, .boolean:
+            return [self]
+        case .array(let array):
+            // The `["set", [...]]` wire form.
+            if array.count == 2,
+               case .string("set") = array[0],
+               case .array(let values) = array[1] {
+                return values
+            }
+            return nil
+        default:
+            return nil
+        }
     }
     
     var setStringValues: [String]? {

--- a/Sources/SwiftOVN/Managers/OVNManager.swift
+++ b/Sources/SwiftOVN/Managers/OVNManager.swift
@@ -843,7 +843,7 @@ public actor OVNManager: OVNManaging {
     
     nonisolated public func monitorUpdates() -> AsyncThrowingStream<OVSDBUpdate, Error> {
         return AsyncThrowingStream { continuation in
-            Task {
+            let task = Task {
                 let updates = connection.monitorUpdates()
                 do {
                     for try await update in updates {
@@ -853,6 +853,11 @@ public actor OVNManager: OVNManaging {
                 } catch {
                     continuation.finish(throwing: error)
                 }
+            }
+            // Cancel the forwarding task if the consumer drops the stream, so it
+            // doesn't outlive them waiting on the underlying connection.
+            continuation.onTermination = { _ in
+                task.cancel()
             }
         }
     }

--- a/Sources/SwiftOVN/Managers/OVSManager.swift
+++ b/Sources/SwiftOVN/Managers/OVSManager.swift
@@ -775,80 +775,48 @@ public actor OVSManager: OVSManaging {
     
     // MARK: - Statistics Operations
 
-    nonisolated public func getBridgeStatistics(bridge: String) async throws -> [String: Any] {
+    nonisolated public func getBridgeStatistics(bridge: String) async throws -> StatisticsDictionary {
         // Bridge statistics are available in the status column
         let condition = OVSDBCondition(column: "name", function: "==", value: .string(bridge))
         let rows = try await connection.select(from: OVSTable.bridge, in: database, where: [condition], columns: ["status", "other_config"])
-        
+
         guard let firstRow = rows.first else {
             return [:]
         }
-        
-        var result: [String: Any] = [:]
-        
-        // Add status information
-        if let status = firstRow["status"] {
-            result["status"] = OVSDBRowDecoder.plainObject(from: status)
-        }
-        
-        // Add other_config information  
-        if let otherConfig = firstRow["other_config"] {
-            result["other_config"] = OVSDBRowDecoder.plainObject(from: otherConfig)
-        }
-        
+
+        var result: StatisticsDictionary = [:]
+        result["status"] = firstRow["status"]
+        result["other_config"] = firstRow["other_config"]
         return result
     }
 
-    nonisolated public func getPortStatistics(port: String) async throws -> [String: Any] {
+    nonisolated public func getPortStatistics(port: String) async throws -> StatisticsDictionary {
         let condition = OVSDBCondition(column: "name", function: "==", value: .string(port))
         let rows = try await connection.select(from: OVSTable.port, in: database, where: [condition], columns: ["status", "external_ids", "other_config"])
-        
+
         guard let firstRow = rows.first else {
             return [:]
         }
-        
-        var result: [String: Any] = [:]
-        
-        // Add available information
-        if let status = firstRow["status"] {
-            result["status"] = OVSDBRowDecoder.plainObject(from: status)
-        }
-        
-        if let externalIds = firstRow["external_ids"] {
-            result["external_ids"] = OVSDBRowDecoder.plainObject(from: externalIds)
-        }
-        
-        if let otherConfig = firstRow["other_config"] {
-            result["other_config"] = OVSDBRowDecoder.plainObject(from: otherConfig)
-        }
-        
+
+        var result: StatisticsDictionary = [:]
+        result["status"] = firstRow["status"]
+        result["external_ids"] = firstRow["external_ids"]
+        result["other_config"] = firstRow["other_config"]
         return result
     }
 
-    nonisolated public func getInterfaceStatistics(interface: String) async throws -> [String: Any] {
+    nonisolated public func getInterfaceStatistics(interface: String) async throws -> StatisticsDictionary {
         let condition = OVSDBCondition(column: "name", function: "==", value: .string(interface))
         let rows = try await connection.select(from: OVSTable.interface, in: database, where: [condition], columns: ["status", "external_ids", "statistics"])
-        
+
         guard let firstRow = rows.first else {
             return [:]
         }
-        
-        var result: [String: Any] = [:]
-        
-        // Add available information
-        if let status = firstRow["status"] {
-            result["status"] = OVSDBRowDecoder.plainObject(from: status)
-        }
-        
-        if let externalIds = firstRow["external_ids"] {
-            result["external_ids"] = OVSDBRowDecoder.plainObject(from: externalIds)
-        }
-        
-        // Interface table might actually have statistics column
-        if let statistics = firstRow["statistics"] {
-            result["statistics"] = OVSDBRowDecoder.plainObject(from: statistics)
-        }
-        
+
+        var result: StatisticsDictionary = [:]
+        result["status"] = firstRow["status"]
+        result["external_ids"] = firstRow["external_ids"]
+        result["statistics"] = firstRow["statistics"]
         return result
     }
     
@@ -870,7 +838,7 @@ public actor OVSManager: OVSManaging {
     
     nonisolated public func monitorUpdates() -> AsyncThrowingStream<OVSDBUpdate, Error> {
         return AsyncThrowingStream { continuation in
-            Task {
+            let task = Task {
                 let updates = connection.monitorUpdates()
                 do {
                     for try await update in updates {
@@ -880,6 +848,11 @@ public actor OVSManager: OVSManaging {
                 } catch {
                     continuation.finish(throwing: error)
                 }
+            }
+            // Cancel the forwarding task if the consumer drops the stream, so it
+            // doesn't outlive them waiting on the underlying connection.
+            continuation.onTermination = { _ in
+                task.cancel()
             }
         }
     }

--- a/Sources/SwiftOVN/Models/JSONRPCResponse.swift
+++ b/Sources/SwiftOVN/Models/JSONRPCResponse.swift
@@ -1,7 +1,11 @@
 import Foundation
 
-public struct JSONRPCResponse<T: Codable>: Codable, @unchecked Sendable {
+public struct JSONRPCResponse<T: Codable>: Codable {
     public let result: T?
     public let error: JSONRPCError?
     public let id: JSONRPCIdentifier?
 }
+
+// Sendable only when the payload is, instead of asserting it unconditionally
+// with `@unchecked`.
+extension JSONRPCResponse: Sendable where T: Sendable {}

--- a/Sources/SwiftOVN/Protocols/OVNManaging.swift
+++ b/Sources/SwiftOVN/Protocols/OVNManaging.swift
@@ -3,8 +3,7 @@ import NIO
 
 // MARK: - OVN Management Protocol
 
-@preconcurrency
-public protocol OVNManaging {
+public protocol OVNManaging: Sendable {
     // Connection Management
     func connect() async throws
     func disconnect() async throws
@@ -136,11 +135,14 @@ public enum OVNTable {
 // MARK: - Helper Extensions
 
 public extension OVNManaging {
-    func connectToNorthbound(socketPath: String = "/var/run/ovn/ovnnb_db.sock") async throws {
+    /// Connects using the endpoint the manager was constructed with. The
+    /// database (northbound/southbound) is fixed at construction time, so
+    /// there is no socket path to pass here.
+    func connectToNorthbound() async throws {
         try await connect()
     }
-    
-    func connectToSouthbound(socketPath: String = "/var/run/ovn/ovnsb_db.sock") async throws {
+
+    func connectToSouthbound() async throws {
         try await connect()
     }
 }

--- a/Sources/SwiftOVN/Protocols/OVSManaging.swift
+++ b/Sources/SwiftOVN/Protocols/OVSManaging.swift
@@ -3,10 +3,12 @@ import NIO
 
 // MARK: - OVS Management Protocol
 
-// Typealias for statistics dictionaries that may contain non-Sendable values
-public typealias StatisticsDictionary = [String: Any]
+/// A column-keyed bag of statistics/status values (e.g. `status`,
+/// `other_config`, `statistics`). Each value keeps its OVSDB wire shape as a
+/// `JSONValue`, so the type is `Sendable` and consistent with the rest of the
+/// typed API.
+public typealias StatisticsDictionary = [String: JSONValue]
 
-@preconcurrency
 public protocol OVSManaging: Sendable {
     // Connection Management
     func connect() async throws
@@ -93,9 +95,9 @@ public protocol OVSManaging: Sendable {
     func deleteQueue(uuid: String) async throws
     
     // Statistics Operations
-    nonisolated func getBridgeStatistics(bridge: String) async throws -> [String: Any]
-    nonisolated func getPortStatistics(port: String) async throws -> [String: Any]
-    nonisolated func getInterfaceStatistics(interface: String) async throws -> [String: Any]
+    func getBridgeStatistics(bridge: String) async throws -> StatisticsDictionary
+    func getPortStatistics(port: String) async throws -> StatisticsDictionary
+    func getInterfaceStatistics(interface: String) async throws -> StatisticsDictionary
     
     // Monitoring
     func startMonitoring(tables: [String]) async throws -> String
@@ -198,7 +200,8 @@ public struct OVSFlowBuilder: Sendable {
 // MARK: - Helper Extensions
 
 public extension OVSManaging {
-    func connectToOVS(socketPath: String = "/var/run/openvswitch/db.sock") async throws {
+    /// Connects using the endpoint the manager was constructed with.
+    func connectToOVS() async throws {
         try await connect()
     }
     

--- a/Tests/SwiftOVNTests/OVNManagerTests.swift
+++ b/Tests/SwiftOVNTests/OVNManagerTests.swift
@@ -112,8 +112,81 @@ final class OVNManagerTests: XCTestCase {
     func testJSONValueUUIDHandling() throws {
         let uuidValue = JSONValue.uuid("12345678-1234-5678-9abc-123456789012")
         let extractedUUID = uuidValue.uuidValue
-        
+
         XCTAssertEqual(extractedUUID, "12345678-1234-5678-9abc-123456789012")
+    }
+
+    // MARK: - JSONValue set/map wire-format assertions
+
+    func testJSONValueSetOfBoolsPreservesBooleans() throws {
+        // Regression: set(_:) previously dropped Bool elements, silently
+        // producing an empty set on the wire.
+        let set = JSONValue.set([true, false])
+
+        guard case .array(let outer) = set, outer.count == 2,
+              case .string("set") = outer[0],
+              case .array(let elements) = outer[1] else {
+            return XCTFail("Expected [\"set\", [...]] shape, got \(set)")
+        }
+        XCTAssertEqual(elements, [.boolean(true), .boolean(false)])
+
+        // And it must serialize as JSON booleans, not 0/1.
+        let json = try JSONSerialization.jsonObject(with: JSONEncoder().encode(set))
+        guard let outer = json as? [Any], outer.count == 2 else {
+            return XCTFail("Expected 2-element array, got \(json)")
+        }
+        XCTAssertEqual(outer[0] as? String, "set")
+        XCTAssertEqual(outer[1] as? [Bool], [true, false])
+    }
+
+    func testJSONValueSingleElementSetIsBareScalar() throws {
+        // RFC 7047: a one-element set is the bare value, not ["set", [value]].
+        XCTAssertEqual(JSONValue.set(["only"]), .string("only"))
+        XCTAssertEqual(JSONValue.set([true]), .boolean(true))
+        XCTAssertEqual(JSONValue.set([42]), .number(42))
+    }
+
+    func testJSONValueSetValueUnwrapsBareScalar() throws {
+        // Regression: the old impossible conjunction made setValue return nil
+        // for a bare scalar instead of a single-element set.
+        XCTAssertEqual(JSONValue.string("x").setValue, [.string("x")])
+        XCTAssertEqual(JSONValue.number(7).setValue, [.number(7)])
+        XCTAssertEqual(JSONValue.boolean(true).setValue, [.boolean(true)])
+        // The wrapped multi-element form still round-trips.
+        XCTAssertEqual(JSONValue.set(["a", "b"]).setValue, [.string("a"), .string("b")])
+    }
+
+    func testStringDictionaryToJSONValueIsMapWireFormat() throws {
+        // toJSONValue() must produce ["map", [[k, v], ...]] so it can build row
+        // columns directly, not a bare JSON object.
+        let value = ["a": "b"].toJSONValue()
+
+        let json = try JSONSerialization.jsonObject(with: JSONEncoder().encode(value))
+        guard let array = json as? [Any], array.count == 2,
+              array[0] as? String == "map",
+              let pairs = array[1] as? [[Any]], pairs.count == 1 else {
+            return XCTFail("Expected [\"map\", [[k, v]]] shape, got \(json)")
+        }
+        XCTAssertEqual(pairs[0][0] as? String, "a")
+        XCTAssertEqual(pairs[0][1] as? String, "b")
+    }
+
+    func testIntDictionaryToJSONValueEncodesIntegerValues() throws {
+        // Integer map values must serialize as JSON integers, not 5.0.
+        let value = ["ttl": 5].toJSONValue()
+
+        let json = try JSONSerialization.jsonObject(with: JSONEncoder().encode(value))
+        let pairs = (json as? [Any])?[1] as? [[Any]]
+        XCTAssertEqual(pairs?.first?[0] as? String, "ttl")
+        XCTAssertEqual(pairs?.first?[1] as? Int, 5)
+    }
+
+    func testOVSDBMutationConvenienceEncodesAsArray() throws {
+        // The convenience builders must produce the RFC 7047 3-tuple wire form.
+        let mutation = OVSDBMutation.insert(column: "ports", value: "lsp0")
+
+        let json = try JSONSerialization.jsonObject(with: JSONEncoder().encode(mutation))
+        XCTAssertEqual(json as? [String], ["ports", "insert", "lsp0"])
     }
     
     func testOVNACLCreation() throws {


### PR DESCRIPTION
Resolves the seven remaining minor findings tracked in #14. All blocker PRs (#13 monitoring, #15 row decoding, #16 attachments, #24 TCP/SSL) have merged, so these are safe to land now.

## Changes

**1. `connect()` race + router locking** — Concurrent `connect()` calls now share a single in-flight future instead of each bootstrapping a channel (which leaked all but the last). `responseRouter` is created before the bootstrap and assigned under `connectionLock` in the success path, not written from inside the channel initializer.

**2. EventLoopGroup shutdown + stream leaks** — The connection tracks `ownsEventLoopGroup` and shuts down a self-created `MultiThreadedEventLoopGroup` in `deinit` (previously leaked a thread per connection). The manager-level `monitorUpdates()` streams now install `onTermination` to cancel their forwarding `Task` when the consumer drops the stream.

**3. Ignored `socketPath` params** — `connectToNorthbound/Southbound/OVS` dropped the `socketPath` argument that did nothing; the endpoint is fixed at construction.

**4. Dead `JSONValue` helper logic** — `setValue` no longer uses an impossible `if case … , case … , case …` conjunction (bare scalars correctly unwrap to a one-element set); `set(_:)` now preserves `Bool` elements; `Dictionary.toJSONValue()` emits the `["map", [[k,v]]]` wire format instead of a plain object.

**5. `JSONRPCResponse` Sendable** — Replaced blanket `@unchecked Sendable` with conditional `Sendable where T: Sendable`; `call<T>` gained the matching constraint.

**6. Typed statistics + `OVNManaging: Sendable`** — `getBridgeStatistics/getPortStatistics/getInterfaceStatistics` now return a `Sendable` `[String: JSONValue]` (`StatisticsDictionary`) instead of `[String: Any]`. `OVNManaging` is now `Sendable`, matching `OVSManaging`.

**7. Wire-format tests** — Added RFC 7047 shape assertions for the set/map helpers (bool sets, single-element bare scalar, map wire format, integer map values) and the mutation convenience builder.

## Not addressed (follow-up)
Finding 5's precision point — `JSONValue.number` stores everything as `Double`, so integers above 2^53 lose precision. Encoding already emits exact integers via `Int64(exactly:)`; adding a dedicated integer case ripples through the decoder/encoder/row layers and is left for a separate change.

## Testing
`swift build` clean; `swift test` → 94 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)