### PR TITLE
Add southbound route models and dynamic routing helpers

### DIFF
--- a/Sources/SwiftOVN/Managers/OVNManager.swift
+++ b/Sources/SwiftOVN/Managers/OVNManager.swift
@@ -902,6 +902,28 @@ public actor OVNManager: OVNManaging {
             try parseRow(row, as: OVNLogicalFlow.self)
         }
     }
+
+    public func getAdvertisedRoutes() async throws -> [OVNAdvertisedRoute] {
+        guard database == OVNDatabase.southbound else {
+            throw OVNManagerError.operationFailed("Advertised Route operations require southbound database")
+        }
+
+        let rows = try await connection.selectAll(from: OVNTable.advertisedRoute, in: database)
+        return try rows.compactMap { row in
+            try parseRow(row, as: OVNAdvertisedRoute.self)
+        }
+    }
+
+    public func getLearnedRoutes() async throws -> [OVNLearnedRoute] {
+        guard database == OVNDatabase.southbound else {
+            throw OVNManagerError.operationFailed("Learned Route operations require southbound database")
+        }
+
+        let rows = try await connection.selectAll(from: OVNTable.learnedRoute, in: database)
+        return try rows.compactMap { row in
+            try parseRow(row, as: OVNLearnedRoute.self)
+        }
+    }
 }
 
 // MARK: - Helper Methods

--- a/Sources/SwiftOVN/Models/OVNAdvertisedRoute.swift
+++ b/Sources/SwiftOVN/Models/OVNAdvertisedRoute.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct OVNAdvertisedRoute: Codable, Sendable {
+    public let uuid: String?
+    public let datapath: String
+    public let logical_port: String
+    public let ip_prefix: String
+    public let tracked_port: String?
+    public let external_ids: [String: String]?
+
+    private enum CodingKeys: String, CodingKey {
+        case uuid = "_uuid"
+        case datapath, logical_port, ip_prefix, tracked_port, external_ids
+    }
+}

--- a/Sources/SwiftOVN/Models/OVNDynamicRouting.swift
+++ b/Sources/SwiftOVN/Models/OVNDynamicRouting.swift
@@ -1,0 +1,198 @@
+import Foundation
+
+public enum OVNDynamicRoutingRedistribute: String, CaseIterable, Sendable {
+    case connected
+    case connectedAsHost = "connected-as-host"
+    case staticRoutes = "static"
+    case nat
+    case loadBalancer = "lb"
+    case hubSpoke = "hub-spoke"
+}
+
+public enum OVNRoutingProtocol: String, CaseIterable, Sendable {
+    case bgp = "BGP"
+    case bfd = "BFD"
+}
+
+public extension OVNLogicalRouter {
+    var dynamicRoutingEnabled: Bool {
+        options?[OVNDynamicRoutingOption.dynamicRouting] == "true"
+    }
+
+    var dynamicRoutingRedistribute: Set<OVNDynamicRoutingRedistribute> {
+        OVNDynamicRoutingOption.redistributeValues(from: options?[OVNDynamicRoutingOption.redistribute])
+    }
+
+    func withDynamicRouting(
+        enabled: Bool = true,
+        redistribute: Set<OVNDynamicRoutingRedistribute>? = nil,
+        vrfID: UInt32? = nil,
+        vrfName: String? = nil,
+        noLearning: Bool? = nil,
+        ipv4PrefixNexthop: String? = nil,
+        ipv6PrefixNexthop: String? = nil
+    ) -> OVNLogicalRouter {
+        var updatedOptions = options ?? [:]
+        updatedOptions[OVNDynamicRoutingOption.dynamicRouting] = String(enabled)
+
+        if let redistribute {
+            updatedOptions[OVNDynamicRoutingOption.redistribute] = OVNDynamicRoutingOption.redistributeString(redistribute)
+        }
+        if let vrfID {
+            updatedOptions[OVNDynamicRoutingOption.vrfID] = String(vrfID)
+        }
+        if let vrfName {
+            updatedOptions[OVNDynamicRoutingOption.vrfName] = vrfName
+        }
+        if let noLearning {
+            updatedOptions[OVNDynamicRoutingOption.noLearning] = String(noLearning)
+        }
+        if let ipv4PrefixNexthop {
+            updatedOptions[OVNDynamicRoutingOption.ipv4PrefixNexthop] = ipv4PrefixNexthop
+        }
+        if let ipv6PrefixNexthop {
+            updatedOptions[OVNDynamicRoutingOption.ipv6PrefixNexthop] = ipv6PrefixNexthop
+        }
+
+        return copy(options: updatedOptions)
+    }
+
+    func withoutDynamicRouting() -> OVNLogicalRouter {
+        var updatedOptions = options ?? [:]
+        for key in OVNDynamicRoutingOption.logicalRouterKeys {
+            updatedOptions.removeValue(forKey: key)
+        }
+        return copy(options: updatedOptions.isEmpty ? nil : updatedOptions)
+    }
+
+    private func copy(options: [String: String]?) -> OVNLogicalRouter {
+        OVNLogicalRouter(
+            uuid: uuid,
+            name: name,
+            ports: ports,
+            static_routes: static_routes,
+            policies: policies,
+            nat: nat,
+            load_balancer: load_balancer,
+            enabled: enabled,
+            options: options,
+            external_ids: external_ids
+        )
+    }
+}
+
+public extension OVNLogicalRouterPort {
+    var dynamicRoutingRedistribute: Set<OVNDynamicRoutingRedistribute> {
+        OVNDynamicRoutingOption.redistributeValues(from: options?[OVNDynamicRoutingOption.redistribute])
+    }
+
+    var routingProtocols: Set<OVNRoutingProtocol> {
+        OVNDynamicRoutingOption.routingProtocolValues(from: options?[OVNDynamicRoutingOption.routingProtocols])
+    }
+
+    func withDynamicRouting(
+        redistribute: Set<OVNDynamicRoutingRedistribute>? = nil,
+        maintainVRF: Bool? = nil,
+        noLearning: Bool? = nil,
+        portName: String? = nil,
+        routingProtocols: Set<OVNRoutingProtocol>? = nil,
+        routingProtocolRedirect: String? = nil
+    ) -> OVNLogicalRouterPort {
+        var updatedOptions = options ?? [:]
+
+        if let redistribute {
+            updatedOptions[OVNDynamicRoutingOption.redistribute] = OVNDynamicRoutingOption.redistributeString(redistribute)
+        }
+        if let maintainVRF {
+            updatedOptions[OVNDynamicRoutingOption.maintainVRF] = String(maintainVRF)
+        }
+        if let noLearning {
+            updatedOptions[OVNDynamicRoutingOption.noLearning] = String(noLearning)
+        }
+        if let portName {
+            updatedOptions[OVNDynamicRoutingOption.portName] = portName
+        }
+        if let routingProtocols {
+            updatedOptions[OVNDynamicRoutingOption.routingProtocols] = OVNDynamicRoutingOption.routingProtocolString(routingProtocols)
+        }
+        if let routingProtocolRedirect {
+            updatedOptions[OVNDynamicRoutingOption.routingProtocolRedirect] = routingProtocolRedirect
+        }
+
+        return copy(options: updatedOptions)
+    }
+
+    func withoutDynamicRoutingOverrides() -> OVNLogicalRouterPort {
+        var updatedOptions = options ?? [:]
+        for key in OVNDynamicRoutingOption.logicalRouterPortKeys {
+            updatedOptions.removeValue(forKey: key)
+        }
+        return copy(options: updatedOptions.isEmpty ? nil : updatedOptions)
+    }
+
+    private func copy(options: [String: String]?) -> OVNLogicalRouterPort {
+        OVNLogicalRouterPort(
+            uuid: uuid,
+            name: name,
+            mac: mac,
+            networks: networks,
+            peer: peer,
+            enabled: enabled,
+            gateway_chassis: gateway_chassis,
+            ha_chassis_group: ha_chassis_group,
+            options: options,
+            external_ids: external_ids
+        )
+    }
+}
+
+private enum OVNDynamicRoutingOption {
+    static let dynamicRouting = "dynamic-routing"
+    static let redistribute = "dynamic-routing-redistribute"
+    static let noLearning = "dynamic-routing-no-learning"
+    static let vrfID = "dynamic-routing-vrf-id"
+    static let vrfName = "dynamic-routing-vrf-name"
+    static let ipv4PrefixNexthop = "dynamic-routing-v4-prefix-nexthop"
+    static let ipv6PrefixNexthop = "dynamic-routing-v6-prefix-nexthop"
+    static let maintainVRF = "dynamic-routing-maintain-vrf"
+    static let portName = "dynamic-routing-port-name"
+    static let routingProtocols = "routing-protocols"
+    static let routingProtocolRedirect = "routing-protocol-redirect"
+
+    static let logicalRouterKeys: Set<String> = [
+        dynamicRouting,
+        redistribute,
+        noLearning,
+        vrfID,
+        vrfName,
+        ipv4PrefixNexthop,
+        ipv6PrefixNexthop,
+    ]
+
+    static let logicalRouterPortKeys: Set<String> = [
+        redistribute,
+        noLearning,
+        maintainVRF,
+        portName,
+        routingProtocols,
+        routingProtocolRedirect,
+    ]
+
+    static func redistributeString(_ values: Set<OVNDynamicRoutingRedistribute>) -> String {
+        values.map(\.rawValue).sorted().joined(separator: ",")
+    }
+
+    static func redistributeValues(from value: String?) -> Set<OVNDynamicRoutingRedistribute> {
+        guard let value else { return [] }
+        return Set(value.split(separator: ",").compactMap { OVNDynamicRoutingRedistribute(rawValue: String($0)) })
+    }
+
+    static func routingProtocolString(_ values: Set<OVNRoutingProtocol>) -> String {
+        values.map(\.rawValue).sorted().joined(separator: ",")
+    }
+
+    static func routingProtocolValues(from value: String?) -> Set<OVNRoutingProtocol> {
+        guard let value else { return [] }
+        return Set(value.split(separator: ",").compactMap { OVNRoutingProtocol(rawValue: String($0)) })
+    }
+}

--- a/Sources/SwiftOVN/Models/OVNLearnedRoute.swift
+++ b/Sources/SwiftOVN/Models/OVNLearnedRoute.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct OVNLearnedRoute: Codable, Sendable {
+    public let uuid: String?
+    public let datapath: String
+    public let logical_port: String
+    public let ip_prefix: String
+    public let nexthop: String
+    public let external_ids: [String: String]?
+
+    private enum CodingKeys: String, CodingKey {
+        case uuid = "_uuid"
+        case datapath, logical_port, ip_prefix, nexthop, external_ids
+    }
+}

--- a/Sources/SwiftOVN/Models/OVNLogicalRouter.swift
+++ b/Sources/SwiftOVN/Models/OVNLogicalRouter.swift
@@ -18,7 +18,22 @@ public struct OVNLogicalRouter: Codable, Sendable {
     }
     
     public init(name: String, ports: [String]? = nil, static_routes: [String]? = nil, policies: [String]? = nil, nat: [String]? = nil, load_balancer: [String]? = nil, enabled: Bool? = true, options: [String: String]? = nil, external_ids: [String: String]? = nil) {
-        self.uuid = nil
+        self.init(
+            uuid: nil,
+            name: name,
+            ports: ports,
+            static_routes: static_routes,
+            policies: policies,
+            nat: nat,
+            load_balancer: load_balancer,
+            enabled: enabled,
+            options: options,
+            external_ids: external_ids
+        )
+    }
+
+    init(uuid: String?, name: String, ports: [String]? = nil, static_routes: [String]? = nil, policies: [String]? = nil, nat: [String]? = nil, load_balancer: [String]? = nil, enabled: Bool? = true, options: [String: String]? = nil, external_ids: [String: String]? = nil) {
+        self.uuid = uuid
         self.name = name
         self.ports = ports
         self.static_routes = static_routes

--- a/Sources/SwiftOVN/Models/OVNLogicalRouterPort.swift
+++ b/Sources/SwiftOVN/Models/OVNLogicalRouterPort.swift
@@ -18,7 +18,22 @@ public struct OVNLogicalRouterPort: Codable, Sendable {
     }
     
     public init(name: String, mac: String, networks: [String], peer: String? = nil, enabled: Bool? = true, gateway_chassis: [String]? = nil, ha_chassis_group: String? = nil, options: [String: String]? = nil, external_ids: [String: String]? = nil) {
-        self.uuid = nil
+        self.init(
+            uuid: nil,
+            name: name,
+            mac: mac,
+            networks: networks,
+            peer: peer,
+            enabled: enabled,
+            gateway_chassis: gateway_chassis,
+            ha_chassis_group: ha_chassis_group,
+            options: options,
+            external_ids: external_ids
+        )
+    }
+
+    init(uuid: String?, name: String, mac: String, networks: [String], peer: String? = nil, enabled: Bool? = true, gateway_chassis: [String]? = nil, ha_chassis_group: String? = nil, options: [String: String]? = nil, external_ids: [String: String]? = nil) {
+        self.uuid = uuid
         self.name = name
         self.mac = mac
         self.networks = networks

--- a/Sources/SwiftOVN/Protocols/OVNManaging.swift
+++ b/Sources/SwiftOVN/Protocols/OVNManaging.swift
@@ -103,6 +103,8 @@ public protocol OVNManaging {
     func getChassisPrivate() async throws -> [OVNChassisPrivate]
     func getPortBindings() async throws -> [OVNPortBinding]
     func getLogicalFlows() async throws -> [OVNLogicalFlow]
+    func getAdvertisedRoutes() async throws -> [OVNAdvertisedRoute]
+    func getLearnedRoutes() async throws -> [OVNLearnedRoute]
 }
 
 // MARK: - OVN Database Constants
@@ -130,6 +132,8 @@ public enum OVNTable {
     public static let chassisPrivate = "Chassis_Private"
     public static let portBinding = "Port_Binding"
     public static let logicalFlow = "Logical_Flow"
+    public static let advertisedRoute = "Advertised_Route"
+    public static let learnedRoute = "Learned_Route"
     public static let encap = "Encap"
 }
 

--- a/Tests/SwiftOVNTests/OVNManagerTests.swift
+++ b/Tests/SwiftOVNTests/OVNManagerTests.swift
@@ -146,6 +146,67 @@ final class OVNManagerTests: XCTestCase {
         XCTAssertEqual(loadBalancer.vips["192.168.1.100:80"], "192.168.1.10:8080,192.168.1.11:8080")
         XCTAssertEqual(loadBalancer.protocolType, "tcp")
     }
+
+    func testLogicalRouterDynamicRoutingHelpers() throws {
+        let router = OVNLogicalRouter(
+            name: "lr0",
+            options: ["existing": "kept"]
+        )
+
+        let dynamicRouter = router.withDynamicRouting(
+            redistribute: [.connected, .staticRoutes, .nat, .loadBalancer],
+            vrfID: 42,
+            vrfName: "tenant-a",
+            noLearning: true,
+            ipv4PrefixNexthop: "192.0.2.1",
+            ipv6PrefixNexthop: "2001:db8::1"
+        )
+
+        XCTAssertTrue(dynamicRouter.dynamicRoutingEnabled)
+        XCTAssertEqual(dynamicRouter.dynamicRoutingRedistribute, [.connected, .staticRoutes, .nat, .loadBalancer])
+        XCTAssertEqual(dynamicRouter.options?["dynamic-routing"], "true")
+        XCTAssertEqual(dynamicRouter.options?["dynamic-routing-redistribute"], "connected,lb,nat,static")
+        XCTAssertEqual(dynamicRouter.options?["dynamic-routing-vrf-id"], "42")
+        XCTAssertEqual(dynamicRouter.options?["dynamic-routing-vrf-name"], "tenant-a")
+        XCTAssertEqual(dynamicRouter.options?["dynamic-routing-no-learning"], "true")
+        XCTAssertEqual(dynamicRouter.options?["dynamic-routing-v4-prefix-nexthop"], "192.0.2.1")
+        XCTAssertEqual(dynamicRouter.options?["dynamic-routing-v6-prefix-nexthop"], "2001:db8::1")
+        XCTAssertEqual(dynamicRouter.options?["existing"], "kept")
+
+        let disabledRouter = dynamicRouter.withoutDynamicRouting()
+        XCTAssertEqual(disabledRouter.options, ["existing": "kept"])
+    }
+
+    func testLogicalRouterPortDynamicRoutingHelpers() throws {
+        let port = OVNLogicalRouterPort(
+            name: "lrp0",
+            mac: "00:00:00:00:00:01",
+            networks: ["10.0.0.1/24"],
+            options: ["existing": "kept"]
+        )
+
+        let dynamicPort = port.withDynamicRouting(
+            redistribute: [.connectedAsHost],
+            maintainVRF: true,
+            noLearning: false,
+            portName: "fabric0",
+            routingProtocols: [.bgp, .bfd],
+            routingProtocolRedirect: "bgp-speaker-lsp"
+        )
+
+        XCTAssertEqual(dynamicPort.dynamicRoutingRedistribute, [.connectedAsHost])
+        XCTAssertEqual(dynamicPort.routingProtocols, [.bgp, .bfd])
+        XCTAssertEqual(dynamicPort.options?["dynamic-routing-redistribute"], "connected-as-host")
+        XCTAssertEqual(dynamicPort.options?["dynamic-routing-maintain-vrf"], "true")
+        XCTAssertEqual(dynamicPort.options?["dynamic-routing-no-learning"], "false")
+        XCTAssertEqual(dynamicPort.options?["dynamic-routing-port-name"], "fabric0")
+        XCTAssertEqual(dynamicPort.options?["routing-protocols"], "BFD,BGP")
+        XCTAssertEqual(dynamicPort.options?["routing-protocol-redirect"], "bgp-speaker-lsp")
+        XCTAssertEqual(dynamicPort.options?["existing"], "kept")
+
+        let clearedPort = dynamicPort.withoutDynamicRoutingOverrides()
+        XCTAssertEqual(clearedPort.options, ["existing": "kept"])
+    }
     
     func testOVSFlowBuilder() throws {
         let flow = OVSFlowBuilder()

--- a/Tests/SwiftOVNTests/OVSDBRowCodingTests.swift
+++ b/Tests/SwiftOVNTests/OVSDBRowCodingTests.swift
@@ -132,6 +132,60 @@ final class OVSDBRowDecoderTests: XCTestCase {
         XCTAssertNil(chassis.transport_zones)
     }
 
+    func testAdvertisedRouteRow() throws {
+        let row: OVSDBRow = [
+            "_uuid": wireUUID(uuidA),
+            "datapath": wireUUID(uuidB),
+            "logical_port": wireUUID(uuidC),
+            "ip_prefix": .string("192.0.2.10/32"),
+            "tracked_port": emptySet,
+            "external_ids": wireStringMap(["owner": "northd"]),
+        ]
+
+        let route = try OVSDBRowDecoder.decode(OVNAdvertisedRoute.self, from: row)
+
+        XCTAssertEqual(route.uuid, uuidA)
+        XCTAssertEqual(route.datapath, uuidB)
+        XCTAssertEqual(route.logical_port, uuidC)
+        XCTAssertEqual(route.ip_prefix, "192.0.2.10/32")
+        XCTAssertNil(route.tracked_port)
+        XCTAssertEqual(route.external_ids, ["owner": "northd"])
+    }
+
+    func testAdvertisedRouteTrackedPortAtom() throws {
+        let row: OVSDBRow = [
+            "_uuid": wireUUID(uuidA),
+            "datapath": wireUUID(uuidB),
+            "logical_port": wireUUID(uuidC),
+            "ip_prefix": .string("10.0.0.0/24"),
+            "tracked_port": wireUUID(uuidC),
+        ]
+
+        let route = try OVSDBRowDecoder.decode(OVNAdvertisedRoute.self, from: row)
+
+        XCTAssertEqual(route.tracked_port, uuidC)
+    }
+
+    func testLearnedRouteRow() throws {
+        let row: OVSDBRow = [
+            "_uuid": wireUUID(uuidA),
+            "datapath": wireUUID(uuidB),
+            "logical_port": wireUUID(uuidC),
+            "ip_prefix": .string("203.0.113.0/24"),
+            "nexthop": .string("192.0.2.254"),
+            "external_ids": wireMap([]),
+        ]
+
+        let route = try OVSDBRowDecoder.decode(OVNLearnedRoute.self, from: row)
+
+        XCTAssertEqual(route.uuid, uuidA)
+        XCTAssertEqual(route.datapath, uuidB)
+        XCTAssertEqual(route.logical_port, uuidC)
+        XCTAssertEqual(route.ip_prefix, "203.0.113.0/24")
+        XCTAssertEqual(route.nexthop, "192.0.2.254")
+        XCTAssertEqual(route.external_ids, [:])
+    }
+
     // MARK: Open_vSwitch
 
     func testInterfaceWithUnsetAndBareScalars() throws {


### PR DESCRIPTION
## Summary
- Add `OVNAdvertisedRoute` and `OVNLearnedRoute` models plus `OVNManager` accessors for southbound route tables.
- Extend `OVNLogicalRouter` and `OVNLogicalRouterPort` with dynamic routing helpers for reading, setting, and clearing routing-related options.
- Update protocol/table definitions and add decoding and helper coverage for the new route and option behavior.

## Testing
- Added unit coverage for advertised route and learned route row decoding, including UUID and set/atom handling.
- Added unit coverage for logical router and router port dynamic routing option helpers.
- Not run (not requested).