### PR TITLE
createBridge: create the bridge-named internal port/interface (add-br semantics)

### DIFF
--- a/Sources/SwiftOVN/Core/OVSDBReferenceTransactions.swift
+++ b/Sources/SwiftOVN/Core/OVSDBReferenceTransactions.swift
@@ -102,4 +102,57 @@ public enum OVSDBReferenceTransactions {
 
         return operations
     }
+
+    /// Operations for creating an OVS bridge the way `ovs-vsctl add-br` does:
+    /// `insert`(Interface) → `insert`(Port) → `insert`(Bridge) →
+    /// `mutate`(Open_vSwitch.bridges += bridge). `ovs-vswitchd` instantiates a
+    /// bridge's Linux netdev from its bridge-named internal Port/Interface
+    /// pair — a bare Bridge row commits fine in OVSDB but never materializes a
+    /// datapath or host-visible device, leaving the bridge inert. All three
+    /// rows are in non-root tables, so the inserts and the chaining references
+    /// must commit in one transaction. The bridge row's `ports` and the port
+    /// row's `interfaces` are overwritten with the `named-uuid` references
+    /// that chain the inserts; the root mutate carries no condition
+    /// (`Open_vSwitch` holds a single row that always exists).
+    public static func insertBridgeAttached(
+        bridgeRow: OVSDBRow,
+        portRow: OVSDBRow,
+        interfaceRow: OVSDBRow
+    ) -> [OVSDBOperation] {
+        var bridgeRow = bridgeRow
+        var portRow = portRow
+        bridgeRow["ports"] = .array([.string("named-uuid"), .string("new_port")])
+        portRow["interfaces"] = .array([.string("named-uuid"), .string("new_interface")])
+
+        return [
+            OVSDBOperation(
+                op: "insert",
+                table: "Interface",
+                row: interfaceRow,
+                uuidName: "new_interface"
+            ),
+            OVSDBOperation(
+                op: "insert",
+                table: "Port",
+                row: portRow,
+                uuidName: "new_port"
+            ),
+            OVSDBOperation(
+                op: "insert",
+                table: "Bridge",
+                row: bridgeRow,
+                uuidName: "new_bridge"
+            ),
+            OVSDBOperation(
+                op: "mutate",
+                table: "Open_vSwitch",
+                whereConditions: [],
+                mutations: [OVSDBMutation(
+                    column: "bridges",
+                    mutator: "insert",
+                    value: .array([.string("named-uuid"), .string("new_bridge")])
+                )]
+            )
+        ]
+    }
 }

--- a/Sources/SwiftOVN/Managers/OVSManager.swift
+++ b/Sources/SwiftOVN/Managers/OVSManager.swift
@@ -66,20 +66,24 @@ public actor OVSManager: OVSManaging {
         return try parseRow(firstRow, as: OVSBridge.self)
     }
     
-    /// Creates a bridge and attaches it to the Open_vSwitch root row
-    /// (Open_vSwitch.bridges) in a single OVSDB transaction, mirroring
-    /// `ovs-vsctl add-br`. Bridge is not a root table, so an unreferenced
-    /// row is garbage-collected when the transaction commits.
+    /// Creates a bridge with its bridge-named internal port/interface pair
+    /// and attaches it to the Open_vSwitch root row (Open_vSwitch.bridges) in
+    /// a single OVSDB transaction, mirroring `ovs-vsctl add-br`. The internal
+    /// pair is what makes `ovs-vswitchd` instantiate the bridge's Linux
+    /// netdev — a bare Bridge row commits fine but never gets a datapath or a
+    /// host-visible device. Bridge, Port, and Interface are not root tables,
+    /// so unreferenced rows are garbage-collected when the transaction
+    /// commits. Any UUIDs in `bridge.ports` are replaced by the new internal
+    /// port. Returns the new bridge's UUID.
     public func createBridge(_ bridge: OVSBridge) async throws -> String {
-        let uuidValue = try await connection.insertAttached(
-            into: OVSTable.bridge,
-            in: database,
-            row: try createRow(from: bridge),
-            uuidName: "new_bridge",
-            parentTable: OVSTable.openVSwitch,
-            parentColumn: "bridges",
-            parentCondition: nil
+        let operations = OVSDBReferenceTransactions.insertBridgeAttached(
+            bridgeRow: try createRow(from: bridge),
+            portRow: try createRow(from: OVSPort(name: bridge.name, interfaces: [])),
+            interfaceRow: try createRow(from: OVSInterface(name: bridge.name, interfaceType: "internal"))
         )
+
+        let results = try await connection.transact(in: database, operations: operations)
+        let uuidValue = try OVSDBConnection.uuid(fromInsertResults: results, at: 2)
 
         logger.info("Created bridge: \(bridge.name)")
         return uuidValue

--- a/Tests/SwiftOVNTests/OVNManagerTests.swift
+++ b/Tests/SwiftOVNTests/OVNManagerTests.swift
@@ -513,6 +513,54 @@ final class JSONRPCClientMockTests: XCTestCase {
         XCTAssertEqual(mutation[2] as? [String], ["named-uuid", "new_bridge"])
     }
 
+    func testInsertBridgeAttachedCreatesInternalPortWireFormat() throws {
+        // `ovs-vsctl add-br` semantics: Interface + Port + Bridge inserted and
+        // chained by named-uuid, then referenced from the Open_vSwitch root.
+        // Without the internal Port/Interface pair, ovs-vswitchd never creates
+        // the bridge's Linux netdev.
+        let operations = OVSDBReferenceTransactions.insertBridgeAttached(
+            bridgeRow: ["name": .string("br-ex"), "ports": .string("stale-caller-value")],
+            portRow: ["name": .string("br-ex")],
+            interfaceRow: ["name": .string("br-ex"), "type": .string("internal")]
+        )
+
+        let json = try encodeOperations(operations)
+        XCTAssertEqual(json.count, 4)
+
+        // Op 0: the internal interface, carrying its uuid-name for the port.
+        XCTAssertEqual(json[0]["op"] as? String, "insert")
+        XCTAssertEqual(json[0]["table"] as? String, "Interface")
+        XCTAssertEqual(json[0]["uuid-name"] as? String, "new_interface")
+        XCTAssertEqual((json[0]["row"] as? [String: Any])?["type"] as? String, "internal")
+
+        // Op 1: the port, its interfaces chained to the new interface.
+        XCTAssertEqual(json[1]["op"] as? String, "insert")
+        XCTAssertEqual(json[1]["table"] as? String, "Port")
+        XCTAssertEqual(json[1]["uuid-name"] as? String, "new_port")
+        XCTAssertEqual(
+            (json[1]["row"] as? [String: Any])?["interfaces"] as? [String],
+            ["named-uuid", "new_interface"])
+
+        // Op 2: the bridge, its ports overwritten with the new port.
+        XCTAssertEqual(json[2]["op"] as? String, "insert")
+        XCTAssertEqual(json[2]["table"] as? String, "Bridge")
+        XCTAssertEqual(json[2]["uuid-name"] as? String, "new_bridge")
+        XCTAssertEqual(
+            (json[2]["row"] as? [String: Any])?["ports"] as? [String],
+            ["named-uuid", "new_port"])
+
+        // Op 3: root reference, unconditioned (the one Open_vSwitch row).
+        XCTAssertEqual(json[3]["op"] as? String, "mutate")
+        XCTAssertEqual(json[3]["table"] as? String, "Open_vSwitch")
+        XCTAssertEqual((json[3]["where"] as? [Any])?.count, 0)
+        guard let mutation = (json[3]["mutations"] as? [[Any]])?.first, mutation.count == 3 else {
+            return XCTFail("Expected one [column, mutator, value] mutation")
+        }
+        XCTAssertEqual(mutation[0] as? String, "bridges")
+        XCTAssertEqual(mutation[1] as? String, "insert")
+        XCTAssertEqual(mutation[2] as? [String], ["named-uuid", "new_bridge"])
+    }
+
     func testDeleteDetachingTransactionWireFormat() throws {
         let uuid = "5e9b0a79-6f38-4e5f-b112-3f0a35b4d2a1"
         let operations = OVSDBReferenceTransactions.deleteDetaching(


### PR DESCRIPTION
## Summary

`createBridge` inserted only the `Bridge` row (attached to `Open_vSwitch.bridges`). That commits fine in OVSDB, but `ovs-vswitchd` only instantiates a bridge's Linux netdev from the bridge-named internal `Port`/`Interface` pair — which `ovs-vsctl add-br` creates and `createBridge` did not. The result is an inert bridge: present in `ovs-vsctl list-br`, but no `ip link` device, so nothing host-side can address it or attach a NIC to it. This is the root cause of samcat116/strato#371, where the Strato agent's provider bridge (`br-ex`) came up with no netdev and the SNAT uplink was silently dead.

## Changes

- `createBridge` now inserts `Interface` (`type=internal`, named after the bridge) → `Port` → `Bridge`, chained by `named-uuid`, and references the bridge from the `Open_vSwitch` root row, all in one transaction — matching `ovs-vsctl add-br`.
- The operation list is built by a new `OVSDBReferenceTransactions.insertBridgeAttached` builder, keeping it unit-testable like `insertAttached`/`deleteDetaching`.
- Wire-format test covering the four operations, the named-uuid chaining, and the unconditioned root mutate.

Callers that pass `bridge.ports` see those UUIDs replaced by the new internal port (documented) — the same stance `createPort(_:withInterface:onBridge:)` takes for `interfaces`.

## Testing

- `swift test`: 108 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)