### PR TITLE
Add ipv6_ra_configs to OVNLogicalRouterPort

### DIFF
--- a/Sources/SwiftOVN/Models/OVNLogicalRouterPort.swift
+++ b/Sources/SwiftOVN/Models/OVNLogicalRouterPort.swift
@@ -9,15 +9,16 @@ public struct OVNLogicalRouterPort: Codable, Sendable {
     public let enabled: Bool?
     public let gateway_chassis: [String]?
     public let ha_chassis_group: String?
+    public let ipv6_ra_configs: [String: String]?
     public let options: [String: String]?
     public let external_ids: [String: String]?
-    
+
     private enum CodingKeys: String, CodingKey {
         case uuid = "_uuid"
-        case name, mac, networks, peer, enabled, gateway_chassis, ha_chassis_group, options, external_ids
+        case name, mac, networks, peer, enabled, gateway_chassis, ha_chassis_group, ipv6_ra_configs, options, external_ids
     }
-    
-    public init(name: String, mac: String, networks: [String], peer: String? = nil, enabled: Bool? = true, gateway_chassis: [String]? = nil, ha_chassis_group: String? = nil, options: [String: String]? = nil, external_ids: [String: String]? = nil) {
+
+    public init(name: String, mac: String, networks: [String], peer: String? = nil, enabled: Bool? = true, gateway_chassis: [String]? = nil, ha_chassis_group: String? = nil, ipv6_ra_configs: [String: String]? = nil, options: [String: String]? = nil, external_ids: [String: String]? = nil) {
         self.init(
             uuid: nil,
             name: name,
@@ -27,12 +28,13 @@ public struct OVNLogicalRouterPort: Codable, Sendable {
             enabled: enabled,
             gateway_chassis: gateway_chassis,
             ha_chassis_group: ha_chassis_group,
+            ipv6_ra_configs: ipv6_ra_configs,
             options: options,
             external_ids: external_ids
         )
     }
 
-    init(uuid: String?, name: String, mac: String, networks: [String], peer: String? = nil, enabled: Bool? = true, gateway_chassis: [String]? = nil, ha_chassis_group: String? = nil, options: [String: String]? = nil, external_ids: [String: String]? = nil) {
+    init(uuid: String?, name: String, mac: String, networks: [String], peer: String? = nil, enabled: Bool? = true, gateway_chassis: [String]? = nil, ha_chassis_group: String? = nil, ipv6_ra_configs: [String: String]? = nil, options: [String: String]? = nil, external_ids: [String: String]? = nil) {
         self.uuid = uuid
         self.name = name
         self.mac = mac
@@ -41,6 +43,7 @@ public struct OVNLogicalRouterPort: Codable, Sendable {
         self.enabled = enabled
         self.gateway_chassis = gateway_chassis
         self.ha_chassis_group = ha_chassis_group
+        self.ipv6_ra_configs = ipv6_ra_configs
         self.options = options
         self.external_ids = external_ids
     }

--- a/Tests/SwiftOVNTests/OVSDBRowCodingTests.swift
+++ b/Tests/SwiftOVNTests/OVSDBRowCodingTests.swift
@@ -422,6 +422,55 @@ final class OVSDBRowEncoderTests: XCTestCase {
         XCTAssertEqual(decoded.external_ids, route.external_ids)
     }
 
+    func testLogicalRouterPortRoundTripWithIPv6RAConfigs() throws {
+        let port = OVNLogicalRouterPort(
+            name: "lrp-net0",
+            mac: "0a:58:0a:00:00:01",
+            networks: ["10.0.0.1/24", "fd12:3456:789a::1/64"],
+            ipv6_ra_configs: ["address_mode": "dhcpv6_stateful", "send_periodic": "true"],
+            options: ["gateway_mtu": "1500"],
+            external_ids: ["owner": "test"]
+        )
+
+        let row = try OVSDBRowEncoder.makeRow(from: port, hints: .ovn)
+        XCTAssertEqual(
+            row["ipv6_ra_configs"],
+            wireStringMap(["address_mode": "dhcpv6_stateful", "send_periodic": "true"])
+        )
+        let decoded = try OVSDBRowDecoder.decode(OVNLogicalRouterPort.self, from: row)
+
+        XCTAssertEqual(decoded.name, port.name)
+        XCTAssertEqual(decoded.mac, port.mac)
+        XCTAssertEqual(decoded.networks, port.networks)
+        XCTAssertEqual(decoded.ipv6_ra_configs, port.ipv6_ra_configs)
+        XCTAssertEqual(decoded.options, port.options)
+        XCTAssertEqual(decoded.external_ids, port.external_ids)
+    }
+
+    /// A router port fresh from ovn-nbctl carries ipv6_ra_configs as an empty
+    /// map; rows from peers that predate the column omit it entirely. Both
+    /// must decode.
+    func testLogicalRouterPortWithoutIPv6RAConfigs() throws {
+        let bareRow: OVSDBRow = [
+            "_uuid": wireUUID(uuidA),
+            "name": .string("lrp-bare"),
+            "mac": .string("0a:58:0a:00:00:01"),
+            "networks": .string("10.0.0.1/24"),
+        ]
+        let bare = try OVSDBRowDecoder.decode(OVNLogicalRouterPort.self, from: bareRow)
+        XCTAssertNil(bare.ipv6_ra_configs)
+
+        let emptyMapRow: OVSDBRow = [
+            "_uuid": wireUUID(uuidA),
+            "name": .string("lrp-empty"),
+            "mac": .string("0a:58:0a:00:00:01"),
+            "networks": .string("10.0.0.1/24"),
+            "ipv6_ra_configs": wireMap([]),
+        ]
+        let empty = try OVSDBRowDecoder.decode(OVNLogicalRouterPort.self, from: emptyMapRow)
+        XCTAssertEqual(empty.ipv6_ra_configs, [:])
+    }
+
     func testPortGroupReferenceColumnsEncodeUUIDAtoms() throws {
         let portGroup = OVNPortGroup(
             name: "pg-web",


### PR DESCRIPTION
Exposes the Logical_Router_Port ipv6_ra_configs column (string-string map per the OVN NB schema) so consumers can configure Router Advertisements — required for IPv6 default routes, which RAs convey rather than DHCPv6.